### PR TITLE
disable baseURL and googleAnalytics for local development

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,7 +1,7 @@
-baseURL = "https://docs.tugboat.qa/"
+#baseURL = "https://docs.tugboat.qa/"
 languageCode = "en-us"
 title = "Tugboat Documentation"
-googleAnalytics = "UA-69911960-4"
+#googleAnalytics = "UA-69911960-4"
 
 # Change the default theme to be use when building the site with Hugo
 theme = "hugo-theme-learn"


### PR DESCRIPTION
I added a step to the deployment job to enable these for production