### PR TITLE
Closes #145 : Add link to tugboat bot article to repo settings page

### DIFF
--- a/content/setting-up-tugboat/select-repo-settings.md
+++ b/content/setting-up-tugboat/select-repo-settings.md
@@ -36,6 +36,11 @@ out:
 - [Using the GitLab integration](../connect-with-your-provider/#using-the-gitlab-integration)
 - [Using the BitBucket integration](../connect-with-your-provider/#using-the-bitbucket-integration)
 
+{{% notice info %}} Want to create a generic user to post comments to your
+linked git provider? Take a look at
+[Add a Tugboat bot to your team](/administer-tugboat-crew/add-tugboat-bot-to-team/)
+for details. {{% /notice %}}
+
 ### Rebuild Orphaned Previews Automatically
 
 When this option is selected, Tugboat automatically


### PR DESCRIPTION
Adding a callout to the Repository Settings page in the docs site to direct people to the article where we explain setting up a Tugboat bot as a user that can post comments to the linked git provider.