### PR TITLE
Closes #146 : Fix broken link to Tugboat images page

### DIFF
--- a/content/setting-up-services/service-images/using-tugboat-images.md
+++ b/content/setting-up-services/service-images/using-tugboat-images.md
@@ -4,9 +4,8 @@ date: 2019-09-19T13:21:53-04:00
 weight: 2
 ---
 
-Tugboat maintains several
-[prebuilt Docker images](../../reference/tugboat-images/). These images are
-extensions of
+Tugboat maintains several [prebuilt Docker images](/reference/tugboat-images/).
+These images are extensions of
 [official Docker images](https://docs.docker.com/docker-hub/official_repos/)
 that include tools and configurations that help them work well with Tugboat.
 Tugboat's images track the upstream images, meaning the `tugboat/httpd:2.4`
@@ -19,8 +18,8 @@ You can check out the scripts we used to create these images on
 [GitHub](https://github.com/TugboatQA/images).
 
 {{% notice note %}} We add new
-[prebuilt service images](../../reference/tugboat-images/) as users need them.
-If there is something you need that we have not yet added,
+[prebuilt service images](/reference/tugboat-images/) as users need them. If
+there is something you need that we have not yet added,
 [let us know](/support/), and we will work with you to try to get it added to
 the list. Alternatively, you are free to choose a generic service image, such as
 `debian`, `ubuntu`, or `centos`, and install any packages you might need.


### PR DESCRIPTION
Fixing the broken link that Cathy pointed out on the Setting up Services -> Service Images -> Using Tugboat Images page.