### PR TITLE
Remove spaces in GitLab integration details

### DIFF
--- a/content/setting-up-tugboat/connect-with-your-provider.md
+++ b/content/setting-up-tugboat/connect-with-your-provider.md
@@ -136,8 +136,7 @@ access in your Project -> Repository Settings:
 - {{% ui-text %}}Set Merge Request build status{{% /ui-text %}} On by default;
   Tugboat updates the merge request build status to reflect the state of its
   Preview.
-- {{% ui-text %}}Post Preview links in Merge Request comments{{% /ui-text %}}
-  Off by default; Tugboat adds a comment to a merge request with links to its
+- {{% ui-text %}}Post Preview links in Merge Request comments{{% /ui-text %}} Off by default; Tugboat adds a comment to a merge request with links to its
   Preview. The comment author is the person who authenticated the git repo to
   Tugboat; to change this, see:
   [Add a Tugboat Bot to your team](../../administer-tugboat-crew/user-admin/#add-a-tugboat-bot-to-your-team).


### PR DESCRIPTION
In the GitLab integration details, Prettier was making some changes that introduced extra spaces and made Hugo render the markdown in the "Off by default" section as a separate paragraph. This is me attempting to remove the spaces manually and see if that fixes the way the markdown rendering creates the HTML, and therefore fixes the formatting issue.