### PR TITLE
Prettier 120

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -9,101 +9,101 @@ services:
             build:
                 - hugo
                 - ln -snf "${TUGBOAT_ROOT}/public" "${DOCROOT}"
-        visualdiffs:
-            - /
-            - /administer-tugboat-crew/
-            - /administer-tugboat-crew/add-a-user/
-            - /administer-tugboat-crew/add-tugboat-bot-to-team/
-            - /administer-tugboat-crew/change-permissions/
-            - /administer-tugboat-crew/remove-a-user/
-            - /administer-tugboat-crew/user-admin/
-            - /building-a-preview/
-            - /building-a-preview/administer-previews/
-            - /building-a-preview/administer-previews/build-previews/
-            - /building-a-preview/administer-previews/change-or-update-previews/
-            - /building-a-preview/administer-previews/change-preview-states/
-            - /building-a-preview/administer-previews/delete-previews/
-            - /building-a-preview/automate-previews/
-            - /building-a-preview/automate-previews/auto-delete/
-            - /building-a-preview/automate-previews/auto-generate/
-            - /building-a-preview/automate-previews/auto-update/
-            - /building-a-preview/preview-deep-dive/
-            - /building-a-preview/preview-deep-dive/how-previews-work/
-            - /building-a-preview/preview-deep-dive/inside-a-preview/
-            - /building-a-preview/preview-deep-dive/optimize-preview-builds/
-            - /building-a-preview/share-a-preview/
-            - /building-a-preview/share-a-preview/auto-share-url/
-            - /building-a-preview/share-a-preview/manually-share-url/
-            - /building-a-preview/work-with-base-previews/
-            - /building-a-preview/work-with-base-previews/building-new-previews/
-            - /building-a-preview/work-with-base-previews/change-or-update/
-            - /building-a-preview/work-with-base-previews/delete-base-preview/
-            - /building-a-preview/work-with-base-previews/set-a-base-preview/
-            - /building-a-preview/work-with-base-previews/stop-using-base-preview/
-            - /faq/
-            - /faq/common-questions/
-            - /faq/compatible-technologies/
-            - /faq/find-tugboat-ids/
-            - /faq/tugboat-ip-addresses/
-            - /reference/
-            - /reference/environment-variables/
-            - /reference/tugboat-configuration/
-            - /reference/tugboat-images/
-            - /setting-up-services/
-            - /setting-up-services/how-to-set-up-services/
-            - /setting-up-services/how-to-set-up-services/clone-git-repositories-into-your-services/
-            - /setting-up-services/how-to-set-up-services/custom-environment-variables/
-            - /setting-up-services/how-to-set-up-services/define-a-default-service/
-            - /setting-up-services/how-to-set-up-services/expose-a-service-http-port/
-            - /setting-up-services/how-to-set-up-services/leverage-service-commands/
-            - /setting-up-services/how-to-set-up-services/name-your-service/
-            - /setting-up-services/how-to-set-up-services/running-a-background-process/
-            - /setting-up-services/how-to-set-up-services/services-in-action/
-            - /setting-up-services/how-to-set-up-services/set-the-document-root-path/
-            - /setting-up-services/how-to-set-up-services/specify-a-service-image/
-            - /setting-up-services/service-images/
-            - /setting-up-services/service-images/docker-pull/
-            - /setting-up-services/service-images/image-version-tags/
-            - /setting-up-services/service-images/mirror-production-with-image/
-            - /setting-up-services/service-images/third-party-docker-images/
-            - /setting-up-services/service-images/using-tugboat-images/
-            - /setting-up-tugboat/
-            - /setting-up-tugboat/add-repos-to-the-project/
-            - /setting-up-tugboat/connect-with-your-provider/
-            - /setting-up-tugboat/create-a-new-project/
-            - /setting-up-tugboat/create-a-tugboat-config-file/
-            - /setting-up-tugboat/select-repo-settings/
-            - /starter-configs/
-            - /starter-configs/code-snippets/
-            - /starter-configs/code-snippets/functional-tests/
-            - /starter-configs/code-snippets/generic-lamp/
-            - /starter-configs/code-snippets/import-mysql-database/
-            - /starter-configs/code-snippets/page-cache/
-            - /starter-configs/code-snippets/phpmyadmin/
-            - /starter-configs/code-snippets/simpletest
-            - /starter-configs/code-snippets/static-html
-            - /starter-configs/code-snippets/tennon-io
-            - /starter-configs/tutorials/
-            - /starter-configs/tutorials/drupal-7/
-            - /starter-configs/tutorials/drupal-8/
-            - /starter-configs/tutorials/pantheon/
-            - /starter-configs/tutorials/wordpress/
-            - /support/
-            - /troubleshooting/
-            - /troubleshooting/debug-config-file/
-            - /troubleshooting/fix-problem-x/
-            - /troubleshooting/preview-built-problem/
-            - /troubleshooting/preview-wont-build/
-            - /tugboat-billing/
-            - /tugboat-billing/cancel-billing/
-            - /tugboat-billing/change-billing-information
-            - /tugboat-billing/change-tugboat-plan/
-            - /tugboat-billing/tugboat-pricing/
-            - /tugboat-cli/
-            - /tugboat-cli/install-the-cli/
-            - /tugboat-cli/set-an-access-token/
-            - /tugboat-cli/use-the-cli/
-            - /visual-diffs/
-            - /visual-diffs/configure-visual-diffs/
-            - /visual-diffs/using-visual-diffs/
-            - /visual-diffs/view-visual-diffs/
+        #visualdiffs:
+        #    - /
+        #    - /administer-tugboat-crew/
+        #    - /administer-tugboat-crew/add-a-user/
+        #    - /administer-tugboat-crew/add-tugboat-bot-to-team/
+        #    - /administer-tugboat-crew/change-permissions/
+        #    - /administer-tugboat-crew/remove-a-user/
+        #    - /administer-tugboat-crew/user-admin/
+        #    - /building-a-preview/
+        #    - /building-a-preview/administer-previews/
+        #    - /building-a-preview/administer-previews/build-previews/
+        #    - /building-a-preview/administer-previews/change-or-update-previews/
+        #    - /building-a-preview/administer-previews/change-preview-states/
+        #    - /building-a-preview/administer-previews/delete-previews/
+        #    - /building-a-preview/automate-previews/
+        #    - /building-a-preview/automate-previews/auto-delete/
+        #    - /building-a-preview/automate-previews/auto-generate/
+        #    - /building-a-preview/automate-previews/auto-update/
+        #    - /building-a-preview/preview-deep-dive/
+        #    - /building-a-preview/preview-deep-dive/how-previews-work/
+        #    - /building-a-preview/preview-deep-dive/inside-a-preview/
+        #    - /building-a-preview/preview-deep-dive/optimize-preview-builds/
+        #    - /building-a-preview/share-a-preview/
+        #    - /building-a-preview/share-a-preview/auto-share-url/
+        #    - /building-a-preview/share-a-preview/manually-share-url/
+        #    - /building-a-preview/work-with-base-previews/
+        #    - /building-a-preview/work-with-base-previews/building-new-previews/
+        #    - /building-a-preview/work-with-base-previews/change-or-update/
+        #    - /building-a-preview/work-with-base-previews/delete-base-preview/
+        #    - /building-a-preview/work-with-base-previews/set-a-base-preview/
+        #    - /building-a-preview/work-with-base-previews/stop-using-base-preview/
+        #    - /faq/
+        #    - /faq/common-questions/
+        #    - /faq/compatible-technologies/
+        #    - /faq/find-tugboat-ids/
+        #    - /faq/tugboat-ip-addresses/
+        #    - /reference/
+        #    - /reference/environment-variables/
+        #    - /reference/tugboat-configuration/
+        #    - /reference/tugboat-images/
+        #    - /setting-up-services/
+        #    - /setting-up-services/how-to-set-up-services/
+        #    - /setting-up-services/how-to-set-up-services/clone-git-repositories-into-your-services/
+        #    - /setting-up-services/how-to-set-up-services/custom-environment-variables/
+        #    - /setting-up-services/how-to-set-up-services/define-a-default-service/
+        #    - /setting-up-services/how-to-set-up-services/expose-a-service-http-port/
+        #    - /setting-up-services/how-to-set-up-services/leverage-service-commands/
+        #    - /setting-up-services/how-to-set-up-services/name-your-service/
+        #    - /setting-up-services/how-to-set-up-services/running-a-background-process/
+        #    - /setting-up-services/how-to-set-up-services/services-in-action/
+        #    - /setting-up-services/how-to-set-up-services/set-the-document-root-path/
+        #    - /setting-up-services/how-to-set-up-services/specify-a-service-image/
+        #    - /setting-up-services/service-images/
+        #    - /setting-up-services/service-images/docker-pull/
+        #    - /setting-up-services/service-images/image-version-tags/
+        #    - /setting-up-services/service-images/mirror-production-with-image/
+        #    - /setting-up-services/service-images/third-party-docker-images/
+        #    - /setting-up-services/service-images/using-tugboat-images/
+        #    - /setting-up-tugboat/
+        #    - /setting-up-tugboat/add-repos-to-the-project/
+        #    - /setting-up-tugboat/connect-with-your-provider/
+        #    - /setting-up-tugboat/create-a-new-project/
+        #    - /setting-up-tugboat/create-a-tugboat-config-file/
+        #    - /setting-up-tugboat/select-repo-settings/
+        #    - /starter-configs/
+        #    - /starter-configs/code-snippets/
+        #    - /starter-configs/code-snippets/functional-tests/
+        #    - /starter-configs/code-snippets/generic-lamp/
+        #    - /starter-configs/code-snippets/import-mysql-database/
+        #    - /starter-configs/code-snippets/page-cache/
+        #    - /starter-configs/code-snippets/phpmyadmin/
+        #    - /starter-configs/code-snippets/simpletest
+        #    - /starter-configs/code-snippets/static-html
+        #    - /starter-configs/code-snippets/tennon-io
+        #    - /starter-configs/tutorials/
+        #    - /starter-configs/tutorials/drupal-7/
+        #    - /starter-configs/tutorials/drupal-8/
+        #    - /starter-configs/tutorials/pantheon/
+        #    - /starter-configs/tutorials/wordpress/
+        #    - /support/
+        #    - /troubleshooting/
+        #    - /troubleshooting/debug-config-file/
+        #    - /troubleshooting/fix-problem-x/
+        #    - /troubleshooting/preview-built-problem/
+        #    - /troubleshooting/preview-wont-build/
+        #    - /tugboat-billing/
+        #    - /tugboat-billing/cancel-billing/
+        #    - /tugboat-billing/change-billing-information
+        #    - /tugboat-billing/change-tugboat-plan/
+        #    - /tugboat-billing/tugboat-pricing/
+        #    - /tugboat-cli/
+        #    - /tugboat-cli/install-the-cli/
+        #    - /tugboat-cli/set-an-access-token/
+        #    - /tugboat-cli/use-the-cli/
+        #    - /visual-diffs/
+        #    - /visual-diffs/configure-visual-diffs/
+        #    - /visual-diffs/using-visual-diffs/
+        #    - /visual-diffs/view-visual-diffs/

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -21,7 +21,7 @@ services:
             - /building-a-preview/administer-previews/
             - /building-a-preview/administer-previews/build-previews/
             - /building-a-preview/administer-previews/change-or-update-previews/
-            - /building-a-preview/administer-previews/change-preview-state/
+            - /building-a-preview/administer-previews/change-preview-states/
             - /building-a-preview/administer-previews/delete-previews/
             - /building-a-preview/automate-previews/
             - /building-a-preview/automate-previews/auto-delete/
@@ -74,15 +74,15 @@ services:
             - /setting-up-tugboat/create-a-tugboat-config-file/
             - /setting-up-tugboat/select-repo-settings/
             - /starter-configs/
-            - /starter-configs/code-snippits/
-            - /starter-configs/code-snippits/functional-tests/
-            - /starter-configs/code-snippits/generic-lamp/
-            - /starter-configs/code-snippits/import-mysql-database/
-            - /starter-configs/code-snippits/page-cache/
-            - /starter-configs/code-snippits/phpmyadmin/
-            - /starter-configs/code-snippits/simpletest
-            - /starter-configs/code-snippits/static-html
-            - /starter-configs/code-snippits/tennon-io
+            - /starter-configs/code-snippets/
+            - /starter-configs/code-snippets/functional-tests/
+            - /starter-configs/code-snippets/generic-lamp/
+            - /starter-configs/code-snippets/import-mysql-database/
+            - /starter-configs/code-snippets/page-cache/
+            - /starter-configs/code-snippets/phpmyadmin/
+            - /starter-configs/code-snippets/simpletest
+            - /starter-configs/code-snippets/static-html
+            - /starter-configs/code-snippets/tennon-io
             - /starter-configs/tutorials/
             - /starter-configs/tutorials/drupal-7/
             - /starter-configs/tutorials/drupal-8/

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -1,13 +1,109 @@
 services:
-  apache:
-    image: tugboatqa/httpd
-    commands:
-      init:
-        - curl -Ls https://github.com/gohugoio/hugo/releases/download/v0.58.3/hugo_0.58.3_Linux-64bit.tar.gz | tar -C /usr/local/bin -zxf - hugo
-        - sed -i '/mod_rewrite/s/#//g' /usr/local/apache2/conf/httpd.conf
-        - sed -i 's/AllowOverride None/AllowOverride All/g' /usr/local/apache2/conf/httpd.conf
-      build:
-        - hugo
-        - ln -snf "${TUGBOAT_ROOT}/public" "${DOCROOT}"
-    visualdiffs:
-      - /setting-up-tugboat/connect-with-your-provider/
+    apache:
+        image: tugboatqa/httpd
+        commands:
+            init:
+                - curl -Ls https://github.com/gohugoio/hugo/releases/download/v0.58.3/hugo_0.58.3_Linux-64bit.tar.gz | tar -C /usr/local/bin -zxf - hugo
+                - sed -i '/mod_rewrite/s/#//g' /usr/local/apache2/conf/httpd.conf
+                - sed -i 's/AllowOverride None/AllowOverride All/g' /usr/local/apache2/conf/httpd.conf
+            build:
+                - hugo
+                - ln -snf "${TUGBOAT_ROOT}/public" "${DOCROOT}"
+        visualdiffs:
+            - /
+            - /administer-tugboat-crew/
+            - /administer-tugboat-crew/add-a-user/
+            - /administer-tugboat-crew/add-tugboat-bot-to-team/
+            - /administer-tugboat-crew/change-permissions/
+            - /administer-tugboat-crew/remove-a-user/
+            - /administer-tugboat-crew/user-admin/
+            - /building-a-preview/
+            - /building-a-preview/administer-previews/
+            - /building-a-preview/administer-previews/build-previews/
+            - /building-a-preview/administer-previews/change-or-update-previews/
+            - /building-a-preview/administer-previews/change-preview-state/
+            - /building-a-preview/administer-previews/delete-previews/
+            - /building-a-preview/automate-previews/
+            - /building-a-preview/automate-previews/auto-delete/
+            - /building-a-preview/automate-previews/auto-generate/
+            - /building-a-preview/automate-previews/auto-update/
+            - /building-a-preview/preview-deep-dive/
+            - /building-a-preview/preview-deep-dive/how-previews-work/
+            - /building-a-preview/preview-deep-dive/inside-a-preview/
+            - /building-a-preview/preview-deep-dive/optimize-preview-builds/
+            - /building-a-preview/share-a-preview/
+            - /building-a-preview/share-a-preview/auto-share-url/
+            - /building-a-preview/share-a-preview/manually-share-url/
+            - /building-a-preview/work-with-base-previews/
+            - /building-a-preview/work-with-base-previews/building-new-previews/
+            - /building-a-preview/work-with-base-previews/change-or-update/
+            - /building-a-preview/work-with-base-previews/delete-base-preview/
+            - /building-a-preview/work-with-base-previews/set-a-base-preview/
+            - /building-a-preview/work-with-base-previews/stop-using-base-preview/
+            - /faq/
+            - /faq/common-questions/
+            - /faq/compatible-technologies/
+            - /faq/find-tugboat-ids/
+            - /faq/tugboat-ip-addresses/
+            - /reference/
+            - /reference/environment-variables/
+            - /reference/tugboat-configuration/
+            - /reference/tugboat-images/
+            - /setting-up-services/
+            - /setting-up-services/how-to-set-up-services/
+            - /setting-up-services/how-to-set-up-services/clone-git-repositories-into-your-services/
+            - /setting-up-services/how-to-set-up-services/custom-environment-variables/
+            - /setting-up-services/how-to-set-up-services/define-a-default-service/
+            - /setting-up-services/how-to-set-up-services/expose-a-service-http-port/
+            - /setting-up-services/how-to-set-up-services/leverage-service-commands/
+            - /setting-up-services/how-to-set-up-services/name-your-service/
+            - /setting-up-services/how-to-set-up-services/running-a-background-process/
+            - /setting-up-services/how-to-set-up-services/services-in-action/
+            - /setting-up-services/how-to-set-up-services/set-the-document-root-path/
+            - /setting-up-services/how-to-set-up-services/specify-a-service-image/
+            - /setting-up-services/
+            - /setting-up-services/docker-pull/
+            - /setting-up-services/image-version-tags/
+            - /setting-up-services/mirror-production-with-image/
+            - /setting-up-services/third-party-docker-images/
+            - /setting-up-services/using-tugboat-images/
+            - /setting-up-tugboat/
+            - /setting-up-tugboat/add-repos-to-the-project/
+            - /setting-up-tugboat/connect-with-your-provider/
+            - /setting-up-tugboat/create-a-new-project/
+            - /setting-up-tugboat/create-a-tugboat-config-file/
+            - /setting-up-tugboat/select-repo-settings/
+            - /starter-configs/
+            - /starter-configs/code-snippits/
+            - /starter-configs/code-snippits/functional-tests/
+            - /starter-configs/code-snippits/generic-lamp/
+            - /starter-configs/code-snippits/import-mysql-database/
+            - /starter-configs/code-snippits/page-cache/
+            - /starter-configs/code-snippits/phpmyadmin/
+            - /starter-configs/code-snippits/simpletest
+            - /starter-configs/code-snippits/static-html
+            - /starter-configs/code-snippits/tennon-io
+            - /starter-configs/tutorials/
+            - /starter-configs/tutorials/drupal-7/
+            - /starter-configs/tutorials/drupal-8/
+            - /starter-configs/tutorials/pantheon/
+            - /starter-configs/tutorials/wordpress/
+            - /support/
+            - /troubleshooting/
+            - /troubleshooting/debug-config-file/
+            - /troubleshooting/fix-problem-x/
+            - /troubleshooting/preview-built-problem/
+            - /troubleshooting/preview-wont-build/
+            - /tugboat-billing/
+            - /tugboat-billing/cancel-billing/
+            - /tugboat-billing/change-billing-information
+            - /tugboat-billing/change-tugboat-plan/
+            - /tugboat-billing/tugboat-pricing/
+            - /tugboat-cli/
+            - /tugboat-cli/install-the-cli/
+            - /tugboat-cli/set-an-access-token/
+            - /tugboat-cli/use-the-cli/
+            - /visual-diffs/
+            - /visual-diffs/configure-visual-diffs/
+            - /visual-diffs/using-visual-diffs/
+            - /visual-diffs/view-visual-diffs/

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -61,12 +61,12 @@ services:
             - /setting-up-services/how-to-set-up-services/services-in-action/
             - /setting-up-services/how-to-set-up-services/set-the-document-root-path/
             - /setting-up-services/how-to-set-up-services/specify-a-service-image/
-            - /setting-up-services/
-            - /setting-up-services/docker-pull/
-            - /setting-up-services/image-version-tags/
-            - /setting-up-services/mirror-production-with-image/
-            - /setting-up-services/third-party-docker-images/
-            - /setting-up-services/using-tugboat-images/
+            - /setting-up-services/service-images/
+            - /setting-up-services/service-images/docker-pull/
+            - /setting-up-services/service-images/image-version-tags/
+            - /setting-up-services/service-images/mirror-production-with-image/
+            - /setting-up-services/service-images/third-party-docker-images/
+            - /setting-up-services/service-images/using-tugboat-images/
             - /setting-up-tugboat/
             - /setting-up-tugboat/add-repos-to-the-project/
             - /setting-up-tugboat/connect-with-your-provider/

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -9,3 +9,5 @@ services:
       build:
         - hugo
         - ln -snf "${TUGBOAT_ROOT}/public" "${DOCROOT}"
+    visualdiffs:
+      - /setting-up-tugboat/connect-with-your-provider/

--- a/README.md
+++ b/README.md
@@ -2,27 +2,24 @@
 
 # Welcome to Tugboat!
 
-Tugboat is a system that builds a working preview of a website for any branch,
-tag, commit, or pull request in a git repository. It can automatically create
-these previews for pull requests by integrating with GitHub, GitLab, or
+Tugboat is a system that builds a working preview of a website for any branch, tag, commit, or pull request in a git
+repository. It can automatically create these previews for pull requests by integrating with GitHub, GitLab, or
 Bitbucket git repositories.
 
-This document aims to provide the information required to use Tugboat. It
-includes tutorials, examples, and references for all experience levels.
+This document aims to provide the information required to use Tugboat. It includes tutorials, examples, and references
+for all experience levels.
 
 ## Contributing
 
-This document is open-source, and is available on
-[GitHub](https://github.com/TugboatQA/docs). If you have any suggestions or
-other feedback about this document, we are happy to hear it!
-[Open a GitHub issue](https://github.com/TugboatQA/docs/issues/new) or email us
-at [support@tugboat.qa](mailto:support@tugboat.qa).
+This document is open-source, and is available on [GitHub](https://github.com/TugboatQA/docs). If you have any
+suggestions or other feedback about this document, we are happy to hear it!
+[Open a GitHub issue](https://github.com/TugboatQA/docs/issues/new) or email us at
+[support@tugboat.qa](mailto:support@tugboat.qa).
 
 ## Theme
 
-The [Hugo Learn Theme](https://github.com/matcornic/hugo-theme-learn) is
-included in this repo as a git subtree. To update the theme, find the latest tag
-at https://github.com/matcornic/hugo-theme-learn/releases and run the following
+The [Hugo Learn Theme](https://github.com/matcornic/hugo-theme-learn) is included in this repo as a git subtree. To
+update the theme, find the latest tag at https://github.com/matcornic/hugo-theme-learn/releases and run the following
 
 ```sh
 export TAG=2.4.0
@@ -31,10 +28,9 @@ git subtree pull --prefix themes/hugo-theme-learn https://github.com/matcornic/h
 
 ## Redirects
 
-Redirects for historic URLs are maintained in `static/.htaccess`. These can be
-tested using [Smolder](https://github.com/sky-shiny/smolder) config file in
-`test/smolder.yaml`. The tests need to be run against a live instance, like a
-Tugboat preview.
+Redirects for historic URLs are maintained in `static/.htaccess`. These can be tested using
+[Smolder](https://github.com/sky-shiny/smolder) config file in `test/smolder.yaml`. The tests need to be run against a
+live instance, like a Tugboat preview.
 
 ```sh
 cat test/smolder.yaml | docker run -i mcameron/smolder pr125-mcktkhcj8krhxo5oaa7emgv5gcnf5e5l.tugboat.qa
@@ -45,5 +41,4 @@ cat test/smolder.yaml | docker run -i mcameron/smolder pr125-mcktkhcj8krhxo5oaa7
 This document is licensed as
 [Creative Commons Attribution-NonCommercial-ShareAlike CC BY-NC-SA](http://creativecommons.org/licenses/by-nc-sa/4.0/legalcode).
 
-Everything not covered above is licensed under the
-[MIT license](https://choosealicense.com/licenses/mit/).
+Everything not covered above is licensed under the [MIT license](https://choosealicense.com/licenses/mit/).

--- a/content/_index.md
+++ b/content/_index.md
@@ -5,26 +5,23 @@ date: 2019-09-17T09:34:20-04:00
 
 # Welcome to Tugboat!
 
-Tugboat is a system that builds a working preview of a website for any branch,
-tag, commit, or pull request in a git repository. It can automatically create
-these previews for pull requests by integrating with GitHub, GitLab, or
+Tugboat is a system that builds a working preview of a website for any branch, tag, commit, or pull request in a git
+repository. It can automatically create these previews for pull requests by integrating with GitHub, GitLab, or
 Bitbucket git repositories.
 
-This document aims to provide the information required to use Tugboat. It
-includes tutorials, examples, and references for all experience levels.
+This document aims to provide the information required to use Tugboat. It includes tutorials, examples, and references
+for all experience levels.
 
 ## Contributing
 
-This document is open-source, and is available on
-[GitHub](https://github.com/TugboatQA/docs). If you have any suggestions or
-other feedback about this document, we are happy to hear it!
-[Open a GitHub issue](https://github.com/TugboatQA/docs/issues/new) or email us
-at [support@tugboat.qa](mailto:support@tugboat.qa).
+This document is open-source, and is available on [GitHub](https://github.com/TugboatQA/docs). If you have any
+suggestions or other feedback about this document, we are happy to hear it!
+[Open a GitHub issue](https://github.com/TugboatQA/docs/issues/new) or email us at
+[support@tugboat.qa](mailto:support@tugboat.qa).
 
 ## License Information
 
 This document is licensed as
 [Creative Commons Attribution-NonCommercial-ShareAlike CC BY-NC-SA](http://creativecommons.org/licenses/by-nc-sa/4.0/legalcode).
 
-Everything not covered above is licensed under the
-[MIT license](https://choosealicense.com/licenses/mit/).
+Everything not covered above is licensed under the [MIT license](https://choosealicense.com/licenses/mit/).

--- a/content/administer-tugboat-crew/add-a-user.md
+++ b/content/administer-tugboat-crew/add-a-user.md
@@ -6,30 +6,23 @@ weight: 1
 
 ## To add a user to a project
 
-1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-   upper-right of the Tugboat screen.
+1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 2. Select the project where you want to add the user.
-3. Click the {{% ui-text %}}Project Settings{{% /ui-text %}} link to the right
-   of the project's title.
-4. In the {{% ui-text %}}Invite a User to This Project{{% /ui-text %}} section,
-   add the recipient's email address, and select the appropriate
-   [user type](#user-permission-levels-explained) from the drop-down.
+3. Click the {{% ui-text %}}Project Settings{{% /ui-text %}} link to the right of the project's title.
+4. In the {{% ui-text %}}Invite a User to This Project{{% /ui-text %}} section, add the recipient's email address, and
+   select the appropriate [user type](#user-permission-levels-explained) from the drop-down.
 5. Press the big blue {{% ui-text %}}Invite{{% /ui-text %}} button!
 
-The user you've invited will get an email from `support@tugboat.qa` with a link
-to accept the invitation.
+The user you've invited will get an email from `support@tugboat.qa` with a link to accept the invitation.
 
-{{% notice info %}} User permissions in Tugboat are handled on a per-project
-basis. When users have access to a project, they have access to all the
-repositories within that project. When inviting users to your project, consider
-whether any of your repos contain sensitive data; you may want to split those
-repos out into a different project, where only a subset of users get access.
-{{% /notice %}}
+{{% notice info %}} User permissions in Tugboat are handled on a per-project basis. When users have access to a project,
+they have access to all the repositories within that project. When inviting users to your project, consider whether any
+of your repos contain sensitive data; you may want to split those repos out into a different project, where only a
+subset of users get access. {{% /notice %}}
 
 {{%expand "Visual Walkthrough" %}}
 
-Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-upper-right of the Tugboat screen.
+Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 
 ![Go to username -> My Projects](../../_images/go-to-user-my-projects.png)
 
@@ -37,14 +30,12 @@ Select the project where you want to add the user.
 
 ![Select the project](../../_images/select-a-project.png)
 
-Click the {{% ui-text %}}Project Settings{{% /ui-text %}} link to the right of
-the project's title.
+Click the {{% ui-text %}}Project Settings{{% /ui-text %}} link to the right of the project's title.
 
 ![Click Project Settings](../../_images/click-project-settings-link.png)
 
-In the {{% ui-text %}}Invite a User to This Project{{% /ui-text %}} section, add
-the recipient's email address, and select the appropriate
-[user type](#user-permission-levels-explained) from the drop-down.
+In the {{% ui-text %}}Invite a User to This Project{{% /ui-text %}} section, add the recipient's email address, and
+select the appropriate [user type](#user-permission-levels-explained) from the drop-down.
 
 ![Add user's email address and select permissions](../../_images/add-user-email-and-permissions.png)
 
@@ -59,9 +50,8 @@ Press the big blue {{% ui-text %}}Invite{{% /ui-text %}} button!
 If the user doesn't see the Tugboat invite:
 
 - Have them check Inboxes and Spam for this email address, or;
-- {{% ui-text %}}Copy Link{{% /ui-text %}} and share it another way from the
-  Pending Invites section of the Project Settings, or;
-- Hit the {{% ui-text %}}Re-send{{% /ui-text %}} link from the Pending Invites
-  section of the Project Settings.
+- {{% ui-text %}}Copy Link{{% /ui-text %}} and share it another way from the Pending Invites section of the Project
+  Settings, or;
+- Hit the {{% ui-text %}}Re-send{{% /ui-text %}} link from the Pending Invites section of the Project Settings.
 
 ![Copy Link or Re-Send from Pending Invites](../../_images/add-user-copy-link-resend.png)

--- a/content/administer-tugboat-crew/add-tugboat-bot-to-team.md
+++ b/content/administer-tugboat-crew/add-tugboat-bot-to-team.md
@@ -4,55 +4,44 @@ date: 2019-09-26T15:16:12-04:00
 weight: 5
 ---
 
-When Tugboat posts comments to a pull request, those comments show as being made
-by the user who linked Tugboat to the git repository. In practice, this means
-that the person who sets up the Tugboat account will get the git provider's
-notifications on pull requests; not because they're intentionally watching or
-commenting on the pull requests, but because of the automated comments that
-Tugboat posts as that person.
+When Tugboat posts comments to a pull request, those comments show as being made by the user who linked Tugboat to the
+git repository. In practice, this means that the person who sets up the Tugboat account will get the git provider's
+notifications on pull requests; not because they're intentionally watching or commenting on the pull requests, but
+because of the automated comments that Tugboat posts as that person.
 
-If you'd instead like those comments to show as coming from Tugboat - and free
-the user who links the account from a barrage of notifications - you can add a
-Tugboat bot to your team.
+If you'd instead like those comments to show as coming from Tugboat - and free the user who links the account from a
+barrage of notifications - you can add a Tugboat bot to your team.
 
 ## To add a Tugboat bot to your team
 
-1. Create an account for your Tugboat bot at your preferred git provider; i.e.
-   GitHub, GitLab, BitBucket.
-2. Optional:
-   [Download the tugboat avatar](https://dashboard.tugboat.qa/static/Tugboat_AvatarLarge.zip)
-   to use for your Tugboat bot account.
-3. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-   upper-right of the Tugboat screen.
+1. Create an account for your Tugboat bot at your preferred git provider; i.e. GitHub, GitLab, BitBucket.
+2. Optional: [Download the tugboat avatar](https://dashboard.tugboat.qa/static/Tugboat_AvatarLarge.zip) to use for your
+   Tugboat bot account.
+3. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 4. Select the project where you want to switch to the Tugboat bot.
-5. Click the {{% ui-text %}}Repository Settings{{% /ui-text %}} link next to the
-   repo where you want to switch to the Tugboat bot.
-6. Scroll down to the {{% ui-text %}}Provider Comments{{% /ui-text %}} section
-   (GitHub Comments, GitLab Comments or BitBucket Comments).
+5. Click the {{% ui-text %}}Repository Settings{{% /ui-text %}} link next to the repo where you want to switch to the
+   Tugboat bot.
+6. Scroll down to the {{% ui-text %}}Provider Comments{{% /ui-text %}} section (GitHub Comments, GitLab Comments or
+   BitBucket Comments).
 7. Press the big blue {{% ui-text %}}Change{{% /ui-text %}} button.
-8. Enter the authentication details for the Tugboat bot user you created at the
-   git provider.
+8. Enter the authentication details for the Tugboat bot user you created at the git provider.
 9. Press the {{% ui-text %}}OK{{% /ui-text %}} button.
 
-Now, whenever Tugboat adds comments to a pull request, the comments will display
-from the Tugboat bot, and the Tugboat bot's account will get any subsequent
-notifications from the provider.
+Now, whenever Tugboat adds comments to a pull request, the comments will display from the Tugboat bot, and the Tugboat
+bot's account will get any subsequent notifications from the provider.
 
 {{%expand "Visual Walkthrough" %}}
 
-Create an account for your Tugboat bot at your preferred git provider; i.e.
-GitHub, GitLab, BitBucket.
+Create an account for your Tugboat bot at your preferred git provider; i.e. GitHub, GitLab, BitBucket.
 
 ![Create an account for your Tugboat bot](../../_images/github-account-for-tugboat-comments.png)
 
-Optional:
-[Download the Tugboat avatar](https://dashboard.tugboat.qa/static/Tugboat_AvatarLarge.zip)
-to use for your Tugboat bot account.
+Optional: [Download the Tugboat avatar](https://dashboard.tugboat.qa/static/Tugboat_AvatarLarge.zip) to use for your
+Tugboat bot account.
 
 ![Update Tugboat bot account with the Tugboat avatar](../../_images/github-account-tugboat-avatar.png)
 
-Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-upper-right of the Tugboat screen.
+Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 
 ![Go to username -> My Projects](../../_images/go-to-user-my-projects.png)
 
@@ -60,13 +49,13 @@ Select the project where you want to switch to the Tugboat bot.
 
 ![Select the project](../../_images/select-a-project.png)
 
-Click the {{% ui-text %}}Repository Settings{{% /ui-text %}} link next to the
-repo where you want to switch to the Tugboat bot.
+Click the {{% ui-text %}}Repository Settings{{% /ui-text %}} link next to the repo where you want to switch to the
+Tugboat bot.
 
 ![Go to Repository Settings](../../_images/go-to-repository-settings.png)
 
-Scroll down to the {{% ui-text %}}Provider Comments{{% /ui-text %}} section
-(GitHub Comments, GitLab Comments or BitBucket Comments).
+Scroll down to the {{% ui-text %}}Provider Comments{{% /ui-text %}} section (GitHub Comments, GitLab Comments or
+BitBucket Comments).
 
 ![Scroll to Provider Comments](../../_images/scroll-to-provider-comments.png)
 
@@ -74,8 +63,7 @@ Press the big blue {{% ui-text %}}Change{{% /ui-text %}} button.
 
 ![Press the Change button](../../_images/provider-comments-press-the-change-button.png)
 
-Enter the authentication details for the Tugboat bot user you created at the git
-provider.
+Enter the authentication details for the Tugboat bot user you created at the git provider.
 
 ![Enter authentication details](../../_images/provider-comments-enter-authentication-details.png)
 

--- a/content/administer-tugboat-crew/change-permissions.md
+++ b/content/administer-tugboat-crew/change-permissions.md
@@ -6,20 +6,16 @@ weight: 3
 
 ## Change user permissions
 
-1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-   upper-right of the Tugboat screen.
+1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 2. Select the project where you want to change user permissions.
-3. Click the {{% ui-text %}}Project Settings{{% /ui-text %}} link to the right
-   of the project's title.
-4. In the {{% ui-text %}}Manage Users{{% /ui-text %}} section, look for the user
-   whose permissions you want to change, and select the appropriate
-   [user type](#user-permission-levels-explained) from the
+3. Click the {{% ui-text %}}Project Settings{{% /ui-text %}} link to the right of the project's title.
+4. In the {{% ui-text %}}Manage Users{{% /ui-text %}} section, look for the user whose permissions you want to change,
+   and select the appropriate [user type](#user-permission-levels-explained) from the
    {{% ui-text %}}Access{{% /ui-text %}} drop-down.
 
 {{%expand "Visual Walkthrough" %}}
 
-Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-upper-right of the Tugboat screen.
+Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 
 ![Go to username -> My Projects](../../_images/go-to-user-my-projects.png)
 
@@ -27,15 +23,13 @@ Select the project where you want to change user permissions.
 
 ![Select the project](../../_images/select-a-project.png)
 
-Click the {{% ui-text %}}Project Settings{{% /ui-text %}} link to the right of
-the project's title.
+Click the {{% ui-text %}}Project Settings{{% /ui-text %}} link to the right of the project's title.
 
 ![Click Project Settings](../../_images/click-project-settings-link.png)
 
-In the {{% ui-text %}}Manage Users{{% /ui-text %}} section, look for the user
-whose permissions you want to change, and select the appropriate
-[user type](#user-permission-levels-explained) from the
-{{% ui-text %}}Access{{% /ui-text %}} drop-down.
+In the {{% ui-text %}}Manage Users{{% /ui-text %}} section, look for the user whose permissions you want to change, and
+select the appropriate [user type](#user-permission-levels-explained) from the {{% ui-text %}}Access{{% /ui-text %}}
+drop-down.
 
 ![Go to Manage Users, click the Access drop-down and select new permissions](../../_images/change-user-permissions-access-drop-down.png)
 

--- a/content/administer-tugboat-crew/remove-a-user.md
+++ b/content/administer-tugboat-crew/remove-a-user.md
@@ -6,18 +6,15 @@ weight: 2
 
 ## To remove a user from a project
 
-1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-   upper-right of the Tugboat screen.
+1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 2. Select the project where you want to remove the user.
-3. Click the {{% ui-text %}}Project Settings{{% /ui-text %}} link to the right
-   of the project's title.
-4. In the {{% ui-text %}}Manage Users{{% /ui-text %}} section, look for the user
-   you want to remove, and click the Remove link.
+3. Click the {{% ui-text %}}Project Settings{{% /ui-text %}} link to the right of the project's title.
+4. In the {{% ui-text %}}Manage Users{{% /ui-text %}} section, look for the user you want to remove, and click the
+   Remove link.
 
 {{%expand "Visual Walkthrough" %}}
 
-Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-upper-right of the Tugboat screen.
+Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 
 ![Go to username -> My Projects](../../_images/go-to-user-my-projects.png)
 
@@ -25,13 +22,12 @@ Select the project where you want to remove the user.
 
 ![Select the project](../../_images/select-a-project.png)
 
-Click the {{% ui-text %}}Project Settings{{% /ui-text %}} link to the right of
-the project's title.
+Click the {{% ui-text %}}Project Settings{{% /ui-text %}} link to the right of the project's title.
 
 ![Click Project Settings](../../_images/click-project-settings-link.png)
 
-In the {{% ui-text %}}Manage Users{{% /ui-text %}} section, look for the user
-you want to remove, and click the Remove link.
+In the {{% ui-text %}}Manage Users{{% /ui-text %}} section, look for the user you want to remove, and click the Remove
+link.
 
 ![Go to Manage Users and click Remove](../../_images/remove-user-click-remove-link.png)
 

--- a/content/administer-tugboat-crew/user-admin.md
+++ b/content/administer-tugboat-crew/user-admin.md
@@ -16,10 +16,8 @@ Tugboat has three different types of users:
 
 Admin users can:
 
-- Manage billing information. This information is disabled if the company is
-  paying with a purchase order.
-- Manage other users, including removing other admins, though they cannot remove
-  themselves.
+- Manage billing information. This information is disabled if the company is paying with a purchase order.
+- Manage other users, including removing other admins, though they cannot remove themselves.
 - Add repositories to the project.
 - Change repository settings.
 - Delete repositories.
@@ -31,8 +29,8 @@ Admin users can:
 Tugboat's generic User's permissions include:
 
 - Manage the repository configuration interface. This includes things like
-  [changing repository settings](/setting-up-tugboat/select-repo-settings/#change-repository-settings),
-  environment variables and SSH keys.
+  [changing repository settings](/setting-up-tugboat/select-repo-settings/#change-repository-settings), environment
+  variables and SSH keys.
 - Manage Previews. Create, remove, rebuild, or lock Previews.
 - Manage Base Previews.
 - Shell access to previews. Manage visual diff screenshots. View build logs.

--- a/content/building-a-preview/administer-previews/_index.md
+++ b/content/building-a-preview/administer-previews/_index.md
@@ -10,7 +10,6 @@ pre = "<b></b>"
 
 # Administer Previews
 
-Build, update, and delete Previews. Change Preview states; Reset, Start/Stop,
-Lock/Unlock.
+Build, update, and delete Previews. Change Preview states; Reset, Start/Stop, Lock/Unlock.
 
 {{% children %}}

--- a/content/building-a-preview/administer-previews/build-previews.md
+++ b/content/building-a-preview/administer-previews/build-previews.md
@@ -9,47 +9,37 @@ You can build a Preview in a few different ways:
 - [Manually build a Preview](#manually-build-a-preview)
 - [Auto-generate Previews](#auto-generate-a-preview)
 
-You can also duplicate a Preview using the [Clone Preview](#duplicate-a-preview)
-option. This is a great option if you want a few copies of a Preview so QA and
-Product can both poke a Preview simultaneously, without worrying about what the
+You can also duplicate a Preview using the [Clone Preview](#duplicate-a-preview) option. This is a great option if you
+want a few copies of a Preview so QA and Product can both poke a Preview simultaneously, without worrying about what the
 other person is doing.
 
 ## Manually build a Preview
 
 To build a Preview:
 
-1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-   upper-right of the Tugboat screen.
+1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 2. Select the project where you want to build a Preview.
-3. Click the name of the repo that contains the code you want to use to build
-   the Preview.
-4. Scroll down to the {{% ui-text %}}Available to Build{{% /ui-text %}} section;
-   by default, you'll see _Pull Requests_, but you can switch to view Branches
-   or Tags that are available to Preview.
-5. Press the {{% ui-text %}}Build Preview{{% /ui-text %}} button to begin the
-   build.
+3. Click the name of the repo that contains the code you want to use to build the Preview.
+4. Scroll down to the {{% ui-text %}}Available to Build{{% /ui-text %}} section; by default, you'll see _Pull Requests_,
+   but you can switch to view Branches or Tags that are available to Preview.
+5. Press the {{% ui-text %}}Build Preview{{% /ui-text %}} button to begin the build.
 
-While the Preview is building, you'll see the Preview appear in the
-{{% ui-text %}}Latest Previews{{% /ui-text %}} section, with a yellow status
-indicator _building_.
+While the Preview is building, you'll see the Preview appear in the {{% ui-text %}}Latest Previews{{% /ui-text %}}
+section, with a yellow status indicator _building_.
 
-When the Preview is ready, the {{% ui-text %}}Preview{{% /ui-text %}} button
-will turn blue, and you'll see a green status indicator _ready_. Press the
-{{% ui-text %}}Preview{{% /ui-text %}} button to view the Preview. While you're
-at it, go ahead and [share your Preview](../../share-a-preview/) - we know
-you're proud of your work!
+When the Preview is ready, the {{% ui-text %}}Preview{{% /ui-text %}} button will turn blue, and you'll see a green
+status indicator _ready_. Press the {{% ui-text %}}Preview{{% /ui-text %}} button to view the Preview. While you're at
+it, go ahead and [share your Preview](../../share-a-preview/) - we know you're proud of your work!
 
-{{% notice note %}} When you go to build a Preview, you may see an arrow
-indicating a drop-down menu next to the **Build Preview** button. This menu
-contains additional options to build your Preview from a Base Preview, or build
-with no Base Preview. For more info on these options, see:
+{{% notice note %}} When you go to build a Preview, you may see an arrow indicating a drop-down menu next to the **Build
+Preview** button. This menu contains additional options to build your Preview from a Base Preview, or build with no Base
+Preview. For more info on these options, see:
 [Building Previews when you're using a Base Preview](../../work-with-base-previews/building-new-previews/).
 {{% /notice %}}
 
 {{%expand "Visual Walkthrough" %}}
 
-Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-upper-right of the Tugboat screen.
+Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 
 ![Go to username -> My Projects](/_images/go-to-user-my-projects.png)
 
@@ -57,84 +47,68 @@ Select the project where you want to build a Preview.
 
 ![Select the project](/_images/select-a-project.png)
 
-Click the name of the repo that contains the code you want to use to build the
-Preview.
+Click the name of the repo that contains the code you want to use to build the Preview.
 
 ![Click into the repository](/_images/manually-build-click-into-repo.png)
 
-Scroll down to the {{% ui-text %}}Available to Build{{% /ui-text %}} section; by
-default, you'll see _Pull Requests_, but you can switch to view Branches or Tags
-that are available to Preview.
+Scroll down to the {{% ui-text %}}Available to Build{{% /ui-text %}} section; by default, you'll see _Pull Requests_,
+but you can switch to view Branches or Tags that are available to Preview.
 
 ![Scroll to Available to Build](/_images/manually-build-scroll-to-available-to-build.png)
 
-Press the {{% ui-text %}}Build Preview{{% /ui-text %}} button to begin the
-build.
+Press the {{% ui-text %}}Build Preview{{% /ui-text %}} button to begin the build.
 
 ![Build preview](/_images/manually-build-click-build-preview-button.png)
 
-While the Preview is building, you'll see the Preview appear in the
-{{% ui-text %}}Latest Previews{{% /ui-text %}} section, with a yellow status
-indicator _building_.
+While the Preview is building, you'll see the Preview appear in the {{% ui-text %}}Latest Previews{{% /ui-text %}}
+section, with a yellow status indicator _building_.
 
 ![Preview building](/_images/manually-build-preview-building.png)
 
-When the Preview is ready, the {{% ui-text %}}Preview{{% /ui-text %}} button
-will turn blue, and you'll see a green status indicator _ready_. Press the
-{{% ui-text %}}Preview{{% /ui-text %}} button to view the Preview. While you're
-at it, go ahead and [share your Preview](../../share-a-preview/) - we know
-you're proud of your work!
+When the Preview is ready, the {{% ui-text %}}Preview{{% /ui-text %}} button will turn blue, and you'll see a green
+status indicator _ready_. Press the {{% ui-text %}}Preview{{% /ui-text %}} button to view the Preview. While you're at
+it, go ahead and [share your Preview](../../share-a-preview/) - we know you're proud of your work!
 
 ![Preview is ready](/_images/preview-ready.png)
 
 {{% /expand%}}
 
-{{% notice note %}} When you look at your new Preview, you'll see the size of
-the Preview next to the branch/tag/PR that the Preview was built from. In the
-example above, the Preview size is 385.49MB. Because
-[billing for Tugboat projects is](/tugboat-billing/tugboat-pricing/#how-does-tugboat-pricing-work),
-in part, based on the total size of all the Previews contained within a project,
-Preview size becomes an important factor when building out multiple Previews.
-Check out our section on
-[Optimizing Preview builds](../../preview-deep-dive/optimize-preview-builds/)
-for tips on
-[reducing Preview size](../../preview-deep-dive/optimize-preview-builds/#optimizing-preview-size).
-{{% /notice %}}
+{{% notice note %}} When you look at your new Preview, you'll see the size of the Preview next to the branch/tag/PR that
+the Preview was built from. In the example above, the Preview size is 385.49MB. Because
+[billing for Tugboat projects is](/tugboat-billing/tugboat-pricing/#how-does-tugboat-pricing-work), in part, based on
+the total size of all the Previews contained within a project, Preview size becomes an important factor when building
+out multiple Previews. Check out our section on
+[Optimizing Preview builds](../../preview-deep-dive/optimize-preview-builds/) for tips on
+[reducing Preview size](../../preview-deep-dive/optimize-preview-builds/#optimizing-preview-size). {{% /notice %}}
 
 ## Auto-generate a Preview
 
-In addition to manually building a Preview when you've got an update, you can
-configure Tugboat to automatically build a Preview when a pull request is
-opened, or when a PR is updated with new code. For more info on this option,
-see: [Auto-generate Previews](../../automate-previews/auto-generate/).
+In addition to manually building a Preview when you've got an update, you can configure Tugboat to automatically build a
+Preview when a pull request is opened, or when a PR is updated with new code. For more info on this option, see:
+[Auto-generate Previews](../../automate-previews/auto-generate/).
 
 ## Duplicate a Preview
 
-When Tugboat successfully completes a Preview build, it takes a snapshot of the
-container at that moment in time. Tugboat uses this snapshot when you
-{{% ui-text %}}Clone{{% /ui-text %}} a Preview, making a near-instantaneous copy
-of that Preview with its own container ID and URL. This enables you to share a
-Tugboat Preview build with multiple people - for example, Joe in QA and Lisa in
-Product - who can then interact with their own version of that Preview without
+When Tugboat successfully completes a Preview build, it takes a snapshot of the container at that moment in time.
+Tugboat uses this snapshot when you {{% ui-text %}}Clone{{% /ui-text %}} a Preview, making a near-instantaneous copy of
+that Preview with its own container ID and URL. This enables you to share a Tugboat Preview build with multiple people -
+for example, Joe in QA and Lisa in Product - who can then interact with their own version of that Preview without
 interfering with what the other folks are doing.
 
 To create a copy of a Preview:
 
-1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-   upper-right of the Tugboat screen.
+1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 2. Select the project where you want to duplicate a Preview.
-3. Click the name of the repo that contains the code you want to use for the
-   duplicate Preview.
+3. Click the name of the repo that contains the code you want to use for the duplicate Preview.
 4. Select the Preview build you want to duplicate.
-5. Click the {{% ui-text %}}Actions{{% /ui-text %}} drop-down menu for that
-   Preview, and select {{% ui-text %}}Clone{{% /ui-text %}}.
+5. Click the {{% ui-text %}}Actions{{% /ui-text %}} drop-down menu for that Preview, and select
+   {{% ui-text %}}Clone{{% /ui-text %}}.
 
 You'll now see a new Preview with the same name as the Preview you cloned.
 
 {{%expand "Visual Walkthrough" %}}
 
-Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-upper-right of the Tugboat screen.
+Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 
 ![Go to username -> My Projects](/_images/go-to-user-my-projects.png)
 
@@ -142,8 +116,7 @@ Select the project where you want to duplicate a Preview.
 
 ![Select the project](/_images/select-a-project.png)
 
-Click the name of the repo that contains the code you want to use for the
-duplicate Preview.
+Click the name of the repo that contains the code you want to use for the duplicate Preview.
 
 ![Click into Tugboat repository](/_images/click-into-tugboat-repository.png)
 
@@ -151,8 +124,8 @@ Select the Preview build you want to duplicate.
 
 ![Select a Preview build](/_images/select-a-preview.png)
 
-Click the {{% ui-text %}}Actions{{% /ui-text %}} drop-down menu for that
-Preview, and select {{% ui-text %}}Clone{{% /ui-text %}}.
+Click the {{% ui-text %}}Actions{{% /ui-text %}} drop-down menu for that Preview, and select
+{{% ui-text %}}Clone{{% /ui-text %}}.
 
 ![Click the Actions drop-down, and select Clone.](/_images/preview-action-clone.png)
 

--- a/content/building-a-preview/administer-previews/change-or-update-previews.md
+++ b/content/building-a-preview/administer-previews/change-or-update-previews.md
@@ -4,27 +4,22 @@ date: 2019-09-24T11:48:14-04:00
 weight: 3
 ---
 
-Want to update or change a Preview build? Tugboat offers a few different ways to
-do that:
+Want to update or change a Preview build? Tugboat offers a few different ways to do that:
 
-- To update a Preview with your latest code, you can
-  [Refresh](#refresh-previews) it. Refreshing a Preview pulls in the latest code
-  from the connected Git repo, and run commands from the from the Tugboat config
-  file's `update` and `build` phases.
-- To change a Preview's Docker images, or the make changes to Services' `init`
-  commands, you can [Rebuild](#rebuild-previews) it. Rebuilding a Preview pulls
-  fresh Docker images, pulls in the latest code from the connected Git repo, and
-  runs all of the Tugboat config file's `init`, `update` and `build` commands.
+- To update a Preview with your latest code, you can [Refresh](#refresh-previews) it. Refreshing a Preview pulls in the
+  latest code from the connected Git repo, and run commands from the from the Tugboat config file's `update` and `build`
+  phases.
+- To change a Preview's Docker images, or the make changes to Services' `init` commands, you can
+  [Rebuild](#rebuild-previews) it. Rebuilding a Preview pulls fresh Docker images, pulls in the latest code from the
+  connected Git repo, and runs all of the Tugboat config file's `init`, `update` and `build` commands.
 
-On a basic level, you can think of it as the difference between updating the
-code (Refresh) and making more substantial changes to the way a Service is
-configured (Rebuild). For more info on what exactly is happening under the
-covers, take a look at
+On a basic level, you can think of it as the difference between updating the code (Refresh) and making more substantial
+changes to the way a Service is configured (Rebuild). For more info on what exactly is happening under the covers, take
+a look at
 [the Preview build process: explained](../../preview-deep-dive/how-previews-work/#the-build-process-explained).
 
-{{% notice note %}} When you're updating a Preview that was built from a Base
-Preview, Rebuild does not pull fresh Docker images and run commands from `init`
-and `update`. Instead, child Previews jump directly to the `build` phase. For
+{{% notice note %}} When you're updating a Preview that was built from a Base Preview, Rebuild does not pull fresh
+Docker images and run commands from `init` and `update`. Instead, child Previews jump directly to the `build` phase. For
 more info, see:
 [rebuild Previews when working with a Base Preview](../../work-with-base-previews/building-new-previews).
 {{% /notice %}}
@@ -37,35 +32,29 @@ When you Refresh a Preview, Tugboat:
 2. Runs commands from the `update` section of the config file.
 3. Runs commands from the `build` section of the config file.
 
-When you're not [using a Base Preview](../../work-with-base-previews/),
-Refreshing is a faster process than building the entire container again, as
-Tugboat doesn't have to set up Services and complete all the `init` processes
-again. However, if you are using a Base Preview, [Rebuild](#rebuild-previews) is
-the faster update process.
+When you're not [using a Base Preview](../../work-with-base-previews/), Refreshing is a faster process than building the
+entire container again, as Tugboat doesn't have to set up Services and complete all the `init` processes again. However,
+if you are using a Base Preview, [Rebuild](#rebuild-previews) is the faster update process.
 
 For more info about build phases, see:
 [the build process: explained](../../preview-deep-dive/how-previews-work/#the-build-process-explained).
 
 ### To Refresh a Preview:
 
-1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-   upper-right of the Tugboat screen.
+1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 2. Select the project where you want to update a Preview.
-3. Click the name of the repo that contains the code you want to use for the
-   Preview update.
+3. Click the name of the repo that contains the code you want to use for the Preview update.
 4. Select the Preview build you want to update.
-5. Click the {{% ui-text %}}Actions{{% /ui-text %}} drop-down menu for that
-   Preview, and select {{% ui-text %}}Refresh{{% /ui-text %}}.
-6. Press the {{% ui-text %}}Yes{{% /ui-text %}} button to confirm and start the
-   Refresh process.
+5. Click the {{% ui-text %}}Actions{{% /ui-text %}} drop-down menu for that Preview, and select
+   {{% ui-text %}}Refresh{{% /ui-text %}}.
+6. Press the {{% ui-text %}}Yes{{% /ui-text %}} button to confirm and start the Refresh process.
 
-You'll see a yellow _refreshing_ status while Tugboat is running the update,
-which will change to a green _ready_ once the update is complete.
+You'll see a yellow _refreshing_ status while Tugboat is running the update, which will change to a green _ready_ once
+the update is complete.
 
 {{%expand "Visual Walkthrough" %}}
 
-Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-upper-right of the Tugboat screen.
+Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 
 ![Go to username -> My Projects](/_images/go-to-user-my-projects.png)
 
@@ -73,8 +62,7 @@ Select the project where you want to update a Preview.
 
 ![Select the project](/_images/select-a-project.png)
 
-Click the name of the repo that contains the code you want to use for the
-Preview update.
+Click the name of the repo that contains the code you want to use for the Preview update.
 
 ![Click into Tugboat repository](/_images/click-into-tugboat-repository.png)
 
@@ -82,18 +70,17 @@ Select the Preview build you want to update.
 
 ![Select a Preview build](/_images/select-a-preview.png)
 
-Click the {{% ui-text %}}Actions{{% /ui-text %}} drop-down menu for that
-Preview, and select {{% ui-text %}}Refresh{{% /ui-text %}}.
+Click the {{% ui-text %}}Actions{{% /ui-text %}} drop-down menu for that Preview, and select
+{{% ui-text %}}Refresh{{% /ui-text %}}.
 
 ![Click the Actions drop-down, and select Refresh.](/_images/preview-action-refresh.png)
 
-Press the {{% ui-text %}}Yes{{% /ui-text %}} button to confirm and start the
-Refresh process.
+Press the {{% ui-text %}}Yes{{% /ui-text %}} button to confirm and start the Refresh process.
 
 ![Press Yes to confirm and begin Refresh](/_images/preview-action-confirm-refresh.png)
 
-You'll see a yellow _refreshing_ status while Tugboat is running the update,
-which will change to a green _ready_ once the update is complete.
+You'll see a yellow _refreshing_ status while Tugboat is running the update, which will change to a green _ready_ once
+the update is complete.
 
 {{% /expand%}}
 
@@ -107,44 +94,36 @@ When you Rebuild a Preview (that was not built using a Base Preview), Tugboat:
 4. Runs commands from the `update` section of the configuration.
 5. Runs commands from the `build` section of the configuration.
 
-When you're not [using a Base Preview](../../work-with-base-previews/), this
-process takes longer than a [Refresh](#refresh-previews), so you should mainly
-use this if you need to pull new Docker images, or run commands from `init` in
-your config.yml. However, if you are using a Base Preview, Rebuild is the faster
-update process.
+When you're not [using a Base Preview](../../work-with-base-previews/), this process takes longer than a
+[Refresh](#refresh-previews), so you should mainly use this if you need to pull new Docker images, or run commands from
+`init` in your config.yml. However, if you are using a Base Preview, Rebuild is the faster update process.
 
 For more info about build phases, see:
 [the build process: explained](../../preview-deep-dive/how-previews-work/#the-build-process-explained).
 
 ### To Rebuild a Preview:
 
-1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-   upper-right of the Tugboat screen.
+1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 2. Select the project where you want to rebuild a Preview.
-3. Click the name of the repo that contains the code you want to use for the
-   Preview rebuild.
+3. Click the name of the repo that contains the code you want to use for the Preview rebuild.
 4. Select the Preview you want to rebuild.
-5. Click the {{% ui-text %}}Actions{{% /ui-text %}} drop-down menu for that
-   Preview, and select {{% ui-text %}}Rebuild{{% /ui-text %}}.
-6. Press the {{% ui-text %}}Yes{{% /ui-text %}} button to confirm and start the
-   Rebuild process.
+5. Click the {{% ui-text %}}Actions{{% /ui-text %}} drop-down menu for that Preview, and select
+   {{% ui-text %}}Rebuild{{% /ui-text %}}.
+6. Press the {{% ui-text %}}Yes{{% /ui-text %}} button to confirm and start the Rebuild process.
 
-You'll see a yellow _building_ status while Tugboat is rebuilding the Preview,
-which will change to a green _ready_ once the build is complete.
+You'll see a yellow _building_ status while Tugboat is rebuilding the Preview, which will change to a green _ready_ once
+the build is complete.
 
-{{% notice note %}} When you Rebuild a Preview that was built from a Base
-Preview, Rebuild does not pull fresh Docker images and run commands from `init`
-and `update`. Instead, child Previews jump directly to the `build` phase. For
-more info, see:
-[updating Previews when working with a Base Preview](../../work-with-base-previews/building-new-previews/).
+{{% notice note %}} When you Rebuild a Preview that was built from a Base Preview, Rebuild does not pull fresh Docker
+images and run commands from `init` and `update`. Instead, child Previews jump directly to the `build` phase. For more
+info, see: [updating Previews when working with a Base Preview](../../work-with-base-previews/building-new-previews/).
 {{% /notice %}}
 
 {{%expand "Visual Walkthrough" %}}
 
 To Rebuild a Preview:
 
-Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-upper-right of the Tugboat screen.
+Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 
 ![Go to username -> My Projects](/_images/go-to-user-my-projects.png)
 
@@ -152,8 +131,7 @@ Select the project where you want to rebuild a Preview.
 
 ![Select the project](/_images/select-a-project.png)
 
-Click the name of the repo that contains the code you want to use for the
-Preview rebuild.
+Click the name of the repo that contains the code you want to use for the Preview rebuild.
 
 ![Click into Tugboat repository](/_images/click-into-tugboat-repository.png)
 
@@ -161,17 +139,16 @@ Select the Preview you want to rebuild.
 
 ![Select a Preview build](/_images/select-a-preview.png)
 
-Click the {{% ui-text %}}Actions{{% /ui-text %}} drop-down menu for that
-Preview, and select {{% ui-text %}}Rebuild{{% /ui-text %}}.
+Click the {{% ui-text %}}Actions{{% /ui-text %}} drop-down menu for that Preview, and select
+{{% ui-text %}}Rebuild{{% /ui-text %}}.
 
 ![Click the Actions drop-down, and select Rebuild.](/_images/preview-action-rebuild.png)
 
-Press the {{% ui-text %}}Yes{{% /ui-text %}} button to confirm and start the
-Rebuild process.
+Press the {{% ui-text %}}Yes{{% /ui-text %}} button to confirm and start the Rebuild process.
 
 ![Press Yes to confirm and begin Rebuild](/_images/preview-action-confirm-rebuild.png)
 
-You'll see a yellow _building_ status while Tugboat is rebuilding the Preview,
-which will change to a green _ready_ once the build is complete.
+You'll see a yellow _building_ status while Tugboat is rebuilding the Preview, which will change to a green _ready_ once
+the build is complete.
 
 {{% /expand%}}

--- a/content/building-a-preview/administer-previews/change-preview-states.md
+++ b/content/building-a-preview/administer-previews/change-preview-states.md
@@ -4,9 +4,8 @@ date: 2019-09-24T11:48:32-04:00
 weight: 7
 ---
 
-When working with Previews, there are a few handy things you can do in the
-{{% ui-text %}}Actions{{% /ui-text %}} menu beyond updating and deleting your
-Previews. You can change the states of your Previews in a few different ways:
+When working with Previews, there are a few handy things you can do in the {{% ui-text %}}Actions{{% /ui-text %}} menu
+beyond updating and deleting your Previews. You can change the states of your Previews in a few different ways:
 
 - [Start, Stop](#start-stop)
 - [Lock, Unlock](#lock-unlock)
@@ -14,36 +13,29 @@ Previews. You can change the states of your Previews in a few different ways:
 
 ## Start, Stop
 
-Sometimes, you might want to stop all of a Preview's Services and take it
-offline. You can use the {{% ui-text %}}Stop{{% /ui-text %}} option in the
-{{% ui-text %}}Actions{{% /ui-text %}} drop-down menu to take the Preview
-offline. This is different from a suspended Preview, in that a suspended Preview
-will start again automatically if someone visits the Preview link, while a
-Stopped Preview remains stopped until someone manually Starts it.
+Sometimes, you might want to stop all of a Preview's Services and take it offline. You can use the
+{{% ui-text %}}Stop{{% /ui-text %}} option in the {{% ui-text %}}Actions{{% /ui-text %}} drop-down menu to take the
+Preview offline. This is different from a suspended Preview, in that a suspended Preview will start again automatically
+if someone visits the Preview link, while a Stopped Preview remains stopped until someone manually Starts it.
 
-On the flip side, Starting a Preview resumes all Services. You can Start a
-Preview that is suspended or Stopped.
+On the flip side, Starting a Preview resumes all Services. You can Start a Preview that is suspended or Stopped.
 
 ### To Start or Stop a Preview:
 
-1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-   upper-right of the Tugboat screen.
+1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 2. Select the project where you want to Stop or Start a Preview.
 3. Click into the repo where you want to Stop/Start a Preview.
 4. Select the Preview you want to Stop or Start.
-5. Click the {{% ui-text %}}Actions{{% /ui-text %}} drop-down menu for that
-   Preview, and select {{% ui-text %}}Stop{{% /ui-text %}} or
-   {{% ui-text %}}Start{{% /ui-text %}}.
+5. Click the {{% ui-text %}}Actions{{% /ui-text %}} drop-down menu for that Preview, and select
+   {{% ui-text %}}Stop{{% /ui-text %}} or {{% ui-text %}}Start{{% /ui-text %}}.
 
-When the Preview is successfully stopped, you'll see a red _stopped_ status.
-When a Preview is Starting, you'll see a yellow _starting_ or _resuming_
-(depending on whether the Preview was Stopped or Suspended), and then the
-Preview will go to a green _ready_ status.
+When the Preview is successfully stopped, you'll see a red _stopped_ status. When a Preview is Starting, you'll see a
+yellow _starting_ or _resuming_ (depending on whether the Preview was Stopped or Suspended), and then the Preview will
+go to a green _ready_ status.
 
 {{%expand "Visual Walkthrough" %}}
 
-Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-upper-right of the Tugboat screen.
+Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 
 ![Go to username -> My Projects](/_images/go-to-user-my-projects.png)
 
@@ -59,50 +51,42 @@ Select the Preview you want to Stop or Start.
 
 ![Select a Preview build](/_images/select-a-preview.png)
 
-Click the {{% ui-text %}}Actions{{% /ui-text %}} drop-down menu for that
-Preview, and select {{% ui-text %}}Stop{{% /ui-text %}} or
-{{% ui-text %}}Start{{% /ui-text %}}.
+Click the {{% ui-text %}}Actions{{% /ui-text %}} drop-down menu for that Preview, and select
+{{% ui-text %}}Stop{{% /ui-text %}} or {{% ui-text %}}Start{{% /ui-text %}}.
 
 ![Click the Actions drop-down, and select Stop or Start.](/_images/preview-action-stop.png)
 
-When the Preview is successfully stopped, you'll see a red _stopped_ status.
-When a Preview is Starting, you'll see a yellow _starting_ or _resuming_
-(depending on whether the Preview was Stopped or Suspended), and then the
-Preview will go to a green _ready_ status.
+When the Preview is successfully stopped, you'll see a red _stopped_ status. When a Preview is Starting, you'll see a
+yellow _starting_ or _resuming_ (depending on whether the Preview was Stopped or Suspended), and then the Preview will
+go to a green _ready_ status.
 
 {{% /expand%}}
 
 ## Lock, Unlock
 
-If you want a Preview to remain in its current state without being updated, you
-can Lock the Preview. Locking a Preview prevents Tugboat from making updates,
-including things like automated updates from new pull request commits, until the
-Preview is Unlocked again. You might want to Lock a Preview to preserve its
-state for a longer review, or to avoid interruptions during a demo.
+If you want a Preview to remain in its current state without being updated, you can Lock the Preview. Locking a Preview
+prevents Tugboat from making updates, including things like automated updates from new pull request commits, until the
+Preview is Unlocked again. You might want to Lock a Preview to preserve its state for a longer review, or to avoid
+interruptions during a demo.
 
-When you're ready to make updates to the Preview again, whether manually or
-automated updates, Unlock the Preview.
+When you're ready to make updates to the Preview again, whether manually or automated updates, Unlock the Preview.
 
 ### To Lock or Unlock a Preview:
 
-1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-   upper-right of the Tugboat screen.
+1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 2. Select the project where you want to Lock or Unlock a Preview.
 3. Click into the repo where you want to Lock/Unlock a Preview.
 4. Select the Preview you want to Lock or Unlock.
-5. Click the {{% ui-text %}}Actions{{% /ui-text %}} drop-down menu for that
-   Preview, and select {{% ui-text %}}Lock{{% /ui-text %}} or
-   {{% ui-text %}}Unlock{{% /ui-text %}}.
+5. Click the {{% ui-text %}}Actions{{% /ui-text %}} drop-down menu for that Preview, and select
+   {{% ui-text %}}Lock{{% /ui-text %}} or {{% ui-text %}}Unlock{{% /ui-text %}}.
 
-When the Preview is successfully locked, you'll see a closed padlock icon next
-to its status - in this example, it's a green icon next to the _ready_ status.
-When the Preview is unlocked, the padlock icon turns into the regular state
+When the Preview is successfully locked, you'll see a closed padlock icon next to its status - in this example, it's a
+green icon next to the _ready_ status. When the Preview is unlocked, the padlock icon turns into the regular state
 indicator.
 
 {{%expand "Visual Walkthrough" %}}
 
-Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-upper-right of the Tugboat screen.
+Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 
 ![Go to username -> My Projects](/_images/go-to-user-my-projects.png)
 
@@ -118,15 +102,13 @@ Select the Preview you want to Lock or Unlock.
 
 ![Select a Preview build](/_images/select-a-preview.png)
 
-Click the {{% ui-text %}}Actions{{% /ui-text %}} drop-down menu for that
-Preview, and select {{% ui-text %}}Lock{{% /ui-text %}} or
-{{% ui-text %}}Unlock{{% /ui-text %}}.
+Click the {{% ui-text %}}Actions{{% /ui-text %}} drop-down menu for that Preview, and select
+{{% ui-text %}}Lock{{% /ui-text %}} or {{% ui-text %}}Unlock{{% /ui-text %}}.
 
 ![Click the Actions drop-down, and select Lock or Unlock.](/_images/preview-action-lock.png)
 
-When the Preview is successfully locked, you'll see a closed padlock icon next
-to its status - in this example, it's a green icon next to the _ready_ status.
-When the Preview is unlocked, the padlock icon turns into the regular state
+When the Preview is successfully locked, you'll see a closed padlock icon next to its status - in this example, it's a
+green icon next to the _ready_ status. When the Preview is unlocked, the padlock icon turns into the regular state
 indicator.
 
 {{% /expand%}}
@@ -134,29 +116,26 @@ indicator.
 ## Reset
 
 When a Preview build completes, Tugboat takes a
-[snapshot of the completed build](../../preview-deep-dive/how-previews-work/#the-build-snapshot).
-If you want to go back to that state - for example, if you want to undo any
-changes that were made during testing or a demo - you can Reset a Preview to go
-back to that post-build snapshot.
+[snapshot of the completed build](../../preview-deep-dive/how-previews-work/#the-build-snapshot). If you want to go back
+to that state - for example, if you want to undo any changes that were made during testing or a demo - you can Reset a
+Preview to go back to that post-build snapshot.
 
 ### To Reset a Preview:
 
-1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-   upper-right of the Tugboat screen.
+1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 2. Select the project where you want to Reset a Preview.
 3. Click into the repo where you want to Reset a Preview.
 4. Select the Preview you want to Reset.
-5. Click the {{% ui-text %}}Actions{{% /ui-text %}} drop-down menu for that
-   Preview, and select {{% ui-text %}}Reset{{% /ui-text %}}.
+5. Click the {{% ui-text %}}Actions{{% /ui-text %}} drop-down menu for that Preview, and select
+   {{% ui-text %}}Reset{{% /ui-text %}}.
 6. Press the {{% ui-text %}}Yes{{% /ui-text %}} button to confirm.
 
-You'll see a yellow _resetting_ status for a moment while the Preview is
-returned to its snapshot state, and then the Preview will become _ready_ again.
+You'll see a yellow _resetting_ status for a moment while the Preview is returned to its snapshot state, and then the
+Preview will become _ready_ again.
 
 {{%expand "Visual Walkthrough" %}}
 
-Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-upper-right of the Tugboat screen.
+Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 
 ![Go to username -> My Projects](/_images/go-to-user-my-projects.png)
 
@@ -172,8 +151,8 @@ Select the Preview you want to Reset.
 
 ![Select a Preview build](/_images/select-a-preview.png)
 
-Click the {{% ui-text %}}Actions{{% /ui-text %}} drop-down menu for that
-Preview, and select {{% ui-text %}}Reset{{% /ui-text %}}.
+Click the {{% ui-text %}}Actions{{% /ui-text %}} drop-down menu for that Preview, and select
+{{% ui-text %}}Reset{{% /ui-text %}}.
 
 ![Click the Actions drop-down, and select Reset.](/_images/preview-action-reset.png)
 
@@ -181,7 +160,7 @@ Press the {{% ui-text %}}Yes{{% /ui-text %}} button to confirm.
 
 ![Press Yes to confirm Reset](/_images/preview-action-confirm-reset.png)
 
-You'll see a yellow _resetting_ status for a moment while the Preview is
-returned to its snapshot state, and then the Preview will become _ready_ again.
+You'll see a yellow _resetting_ status for a moment while the Preview is returned to its snapshot state, and then the
+Preview will become _ready_ again.
 
 {{% /expand%}}

--- a/content/building-a-preview/administer-previews/delete-previews.md
+++ b/content/building-a-preview/administer-previews/delete-previews.md
@@ -4,26 +4,23 @@ date: 2019-09-24T11:48:24-04:00
 weight: 5
 ---
 
-Need to get rid of a Preview you're not using anymore? Each Preview in your
-Tugboat project counts toward the total
-[storage size for Tugboat billing](/tugboat-billing/tugboat-pricing/#how-does-tugboat-pricing-work),
-so it's a good idea to get rid of Previews you don't need.
+Need to get rid of a Preview you're not using anymore? Each Preview in your Tugboat project counts toward the total
+[storage size for Tugboat billing](/tugboat-billing/tugboat-pricing/#how-does-tugboat-pricing-work), so it's a good idea
+to get rid of Previews you don't need.
 
 ### To delete a Preview:
 
-1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-   upper-right of the Tugboat screen.
+1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 2. Select the project where you want to delete a Preview.
 3. Click into the repo where you want to delete a Preview.
 4. Select the Preview you want to delete.
-5. Click the {{% ui-text %}}Actions{{% /ui-text %}} drop-down menu for that
-   Preview, and select {{% ui-text %}}Delete{{% /ui-text %}}.
+5. Click the {{% ui-text %}}Actions{{% /ui-text %}} drop-down menu for that Preview, and select
+   {{% ui-text %}}Delete{{% /ui-text %}}.
 6. Press the {{% ui-text %}}Yes{{% /ui-text %}} button to confirm.
 
 {{%expand "Visual Walkthrough" %}}
 
-Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-upper-right of the Tugboat screen.
+Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 
 ![Go to username -> My Projects](/_images/go-to-user-my-projects.png)
 
@@ -39,8 +36,8 @@ Select the Preview you want to delete.
 
 ![Select a Preview build](/_images/select-a-preview.png)
 
-Click the {{% ui-text %}}Actions{{% /ui-text %}} drop-down menu for that
-Preview, and select {{% ui-text %}}Delete{{% /ui-text %}}.
+Click the {{% ui-text %}}Actions{{% /ui-text %}} drop-down menu for that Preview, and select
+{{% ui-text %}}Delete{{% /ui-text %}}.
 
 ![Click the Actions drop-down, and select Delete.](/_images/preview-action-delete.png)
 

--- a/content/building-a-preview/automate-previews/auto-delete.md
+++ b/content/building-a-preview/automate-previews/auto-delete.md
@@ -4,35 +4,27 @@ date: 2019-09-24T11:49:57-04:00
 weight: 5
 ---
 
-Each of the Previews in your Tugboat project count toward the total storage
-space available in your
-[project's billing tier](/tugboat-billing/tugboat-pricing/). By default, Tugboat
-is configured to automatically delete Previews when their corresponding git pull
-requests are merged or closed.
+Each of the Previews in your Tugboat project count toward the total storage space available in your
+[project's billing tier](/tugboat-billing/tugboat-pricing/). By default, Tugboat is configured to automatically delete
+Previews when their corresponding git pull requests are merged or closed.
 
 ## To automatically delete Previews:
 
-If you want to change the setting to automatically delete Previews when their
-PRs are merged or closed:
+If you want to change the setting to automatically delete Previews when their PRs are merged or closed:
 
-1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-   upper-right of the Tugboat screen.
-2. Select the project where you want to configure auto-delete settings for
-   Previews.
+1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
+2. Select the project where you want to configure auto-delete settings for Previews.
 3. Click into {{% ui-text %}}Settings{{% /ui-text %}} for the repository.
 4. Click the checkbox to change the setting.
-5. Press the {{% ui-text %}}Save Configuration{{% /ui-text %}} button to save
-   your changes.
+5. Press the {{% ui-text %}}Save Configuration{{% /ui-text %}} button to save your changes.
 
 {{%expand "Visual Walkthrough" %}}
 
-Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-upper-right of the Tugboat screen.
+Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 
 ![Go to username -> My Projects](/_images/go-to-user-my-projects.png)
 
-Select the project where you want to configure auto-delete settings for
-Previews.
+Select the project where you want to configure auto-delete settings for Previews.
 
 ![Select the project](/_images/select-a-project.png)
 
@@ -44,8 +36,7 @@ Click the checkbox to change the setting.
 
 ![Click the checkbox to turn auto-delete Preview on or off](/_images/auto-delete-preview-repository-settings.png)
 
-Press the {{% ui-text %}}Save Configuration{{% /ui-text %}} button to save your
-changes.
+Press the {{% ui-text %}}Save Configuration{{% /ui-text %}} button to save your changes.
 
 ![Press the Save Configuration button](/_images/repository-settings-press-save-configuration.png)
 

--- a/content/building-a-preview/automate-previews/auto-generate.md
+++ b/content/building-a-preview/automate-previews/auto-generate.md
@@ -4,21 +4,18 @@ date: 2019-09-24T11:49:35-04:00
 weight: 1
 ---
 
-We love automatically generating Previews from new pull requests - we think it's
-one of Tugboat's best features! {{% ui-text %}}Build Pull Requests
-Automatically{{% /ui-text %}} kicks off a new Preview build whenever a pull
-request is opened in your linked git repository.
+We love automatically generating Previews from new pull requests - we think it's one of Tugboat's best features!
+{{% ui-text %}}Build Pull Requests Automatically{{% /ui-text %}} kicks off a new Preview build whenever a pull request
+is opened in your linked git repository.
 
-If you're [using a Base Preview](/building-a-preview/work-with-base-previews/),
-the automated Preview build starts from that Base Preview.
+If you're [using a Base Preview](/building-a-preview/work-with-base-previews/), the automated Preview build starts from
+that Base Preview.
 
-{{% notice warning %}} When you enable this functionality, Tugboat does not
-automatically build pull requests from forked repositories. That requires you to
-set an additional option: **Build Previews for Forked Pull Requests**. Any
-secrets in your Preview will be accessible by the owner of the forked
-repository, so this setting is turned off by default. Automated Preview Build
-requests from forked repositories appear as failed Preview builds in your
-Tugboat Dashboard. For more info, see:
+{{% notice warning %}} When you enable this functionality, Tugboat does not automatically build pull requests from
+forked repositories. That requires you to set an additional option: **Build Previews for Forked Pull Requests**. Any
+secrets in your Preview will be accessible by the owner of the forked repository, so this setting is turned off by
+default. Automated Preview Build requests from forked repositories appear as failed Preview builds in your Tugboat
+Dashboard. For more info, see:
 [Troubleshooting -> Tugboat Error Messages 1074](/troubleshooting/fix-problem-x/#1074-repo-configuration-does-not-allow-building-of-pull-requests-from-forks).
 {{% /notice %}}
 
@@ -26,33 +23,25 @@ Tugboat Dashboard. For more info, see:
 
 To configure Tugboat to auto-generate Previews, you'll need to:
 
-1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-   upper-right of the Tugboat screen.
-2. Select the project where you want to configure auto-generate settings for
-   Previews.
+1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
+2. Select the project where you want to configure auto-generate settings for Previews.
 3. Click into {{% ui-text %}}Settings{{% /ui-text %}} for the repository.
-4. Click the checkboxes for the auto-generate features you'd like to turn
-   on/off.
-5. Press the {{% ui-text %}}Save Configuration{{% /ui-text %}} button to save
-   your changes.
+4. Click the checkboxes for the auto-generate features you'd like to turn on/off.
+5. Press the {{% ui-text %}}Save Configuration{{% /ui-text %}} button to save your changes.
 
-{{% notice tip %}} Don't see the options to auto-generate Previews from pull
-requests? You'll need to
-[connect your preferred git provider to Tugboat](/setting-up-tugboat/connect-with-your-provider/),
-and then
+{{% notice tip %}} Don't see the options to auto-generate Previews from pull requests? You'll need to
+[connect your preferred git provider to Tugboat](/setting-up-tugboat/connect-with-your-provider/), and then
 [delete](/setting-up-tugboat/select-repo-settings/#delete-the-repository) and
-[re-add the provider-specific version of the repository](/setting-up-tugboat/add-repos-to-the-project/)
-to your Tugboat project. {{% /notice %}}
+[re-add the provider-specific version of the repository](/setting-up-tugboat/add-repos-to-the-project/) to your Tugboat
+project. {{% /notice %}}
 
 {{%expand "Visual Walkthrough" %}}
 
-Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-upper-right of the Tugboat screen.
+Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 
 ![Go to username -> My Projects](/_images/go-to-user-my-projects.png)
 
-Select the project where you want to configure auto-generate settings for
-Previews.
+Select the project where you want to configure auto-generate settings for Previews.
 
 ![Select the project](/_images/select-a-project.png)
 
@@ -64,8 +53,7 @@ Click the checkboxes for the auto-generate features you'd like to turn on/off.
 
 ![Click the checkboxes to turn auto-build Preview options on or off](/_images/auto-build-preview-repository-settings.png)
 
-Press the {{% ui-text %}}Save Configuration{{% /ui-text %}} button to save your
-changes.
+Press the {{% ui-text %}}Save Configuration{{% /ui-text %}} button to save your changes.
 
 ![Press the Save Configuration button](/_images/repository-settings-press-save-configuration.png)
 

--- a/content/building-a-preview/automate-previews/auto-update.md
+++ b/content/building-a-preview/automate-previews/auto-update.md
@@ -4,69 +4,52 @@ date: 2019-09-24T11:49:50-04:00
 weight: 3
 ---
 
-You can set Tugboat to automatically update Previews in a couple of different
-ways. First is the most straightforward:
+You can set Tugboat to automatically update Previews in a couple of different ways. First is the most straightforward:
 
 {{% ui-text %}}Rebuild Updated Pull Requests Automatically{{% /ui-text %}}
 
-When you select this setting, Tugboat automatically rebuilds a Preview when the
-corresponding pull request is updated.
+When you select this setting, Tugboat automatically rebuilds a Preview when the corresponding pull request is updated.
 
-Besides auto-generating Previews from pull requests, you can also auto-generate
-Previews when you make changes to a Base Preview. If you've
-[set a Base Preview](../../work-with-base-previews/set-a-base-preview/), you can
-have Tugboat:
+Besides auto-generating Previews from pull requests, you can also auto-generate Previews when you make changes to a Base
+Preview. If you've [set a Base Preview](../../work-with-base-previews/set-a-base-preview/), you can have Tugboat:
 
 {{% ui-text %}}Rebuild Orphaned Previews Automatically{{% /ui-text %}}
 
-When you
-[rebuild a Base Preview](../../work-with-base-previews/change-or-update/#change-a-base-preview),
-any changes in the Base Preview don't automatically carry over to existing child
-Previews; they become orphaned. New Previews that are built from a rebuilt Base
-Preview carry forward the changes, but existing Previews maintain the old
-configuration and data.
+When you [rebuild a Base Preview](../../work-with-base-previews/change-or-update/#change-a-base-preview), any changes in
+the Base Preview don't automatically carry over to existing child Previews; they become orphaned. New Previews that are
+built from a rebuilt Base Preview carry forward the changes, but existing Previews maintain the old configuration and
+data.
 
-When you enable the `Rebuild Orphaned Previews Automatically` setting, Tugboat
-automatically rebuilds child Previews when the Base Preview they were built from
-is rebuilt. This pulls in the changes that you make to the Base Preview during
-the rebuild process, and keeps child Previews in step with the Base Previews
-that generated them.
+When you enable the `Rebuild Orphaned Previews Automatically` setting, Tugboat automatically rebuilds child Previews
+when the Base Preview they were built from is rebuilt. This pulls in the changes that you make to the Base Preview
+during the rebuild process, and keeps child Previews in step with the Base Previews that generated them.
 
 {{% ui-text %}}Rebuild Stale Previews Automatically{{% /ui-text %}}
 
-When you
-[refresh a Base Preview](../../work-with-base-previews/change-or-update/#update-a-base-preview),
-the updates that you make to the Base Preview don't automatically carry over to
-existing child Previews. The Base Preview and new Previews built on the Base
-Preview may have fresh data and other updates, while existing child Previews
-keep their stale data.
+When you [refresh a Base Preview](../../work-with-base-previews/change-or-update/#update-a-base-preview), the updates
+that you make to the Base Preview don't automatically carry over to existing child Previews. The Base Preview and new
+Previews built on the Base Preview may have fresh data and other updates, while existing child Previews keep their stale
+data.
 
-When you enable the `Rebuild Stale Previews Automatically` setting, Tugboat
-automatically rebuilds child Previews when the Base Preview they were built from
-is refreshed. This pulls in the updates that you make to the Base Preview during
-the refresh process, ensuring that child Previews always have the most recent
-data and updates.
+When you enable the `Rebuild Stale Previews Automatically` setting, Tugboat automatically rebuilds child Previews when
+the Base Preview they were built from is refreshed. This pulls in the updates that you make to the Base Preview during
+the refresh process, ensuring that child Previews always have the most recent data and updates.
 
 ## To set Tugboat to automatically update Previews
 
-1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-   upper-right of the Tugboat screen.
-2. Select the project where you want to configure auto-update settings for
-   Previews.
+1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
+2. Select the project where you want to configure auto-update settings for Previews.
 3. Click into {{% ui-text %}}Settings{{% /ui-text %}} for the repository.
 4. Click the checkboxes to change the settings you want to adjust.
-5. Press the {{% ui-text %}}Save Configuration{{% /ui-text %}} button to save
-   your changes.
+5. Press the {{% ui-text %}}Save Configuration{{% /ui-text %}} button to save your changes.
 
 {{%expand "Visual Walkthrough" %}}
 
-Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-upper-right of the Tugboat screen.
+Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 
 ![Go to username -> My Projects](/_images/go-to-user-my-projects.png)
 
-Select the project where you want to configure auto-update settings for
-Previews.
+Select the project where you want to configure auto-update settings for Previews.
 
 ![Select the project](/_images/select-a-project.png)
 
@@ -78,8 +61,7 @@ Click the checkboxes to change the settings you want to adjust.
 
 ![Click the checkboxes to turn auto-update Preview options on or off](/_images/auto-update-preview-repository-settings.png)
 
-Press the {{% ui-text %}}Save Configuration{{% /ui-text %}} button to save your
-changes.
+Press the {{% ui-text %}}Save Configuration{{% /ui-text %}} button to save your changes.
 
 ![Press the Save Configuration button](/_images/repository-settings-press-save-configuration.png)
 

--- a/content/building-a-preview/preview-deep-dive/_index.md
+++ b/content/building-a-preview/preview-deep-dive/_index.md
@@ -10,7 +10,7 @@ pre = "<b> </b>"
 
 # Inside Previews
 
-Learn more about how Previews work, how you can optimize your Preview builds,
-and what you'll see when you click into a Preview in the Tugboat dashboard.
+Learn more about how Previews work, how you can optimize your Preview builds, and what you'll see when you click into a
+Preview in the Tugboat dashboard.
 
 {{% children %}}

--- a/content/building-a-preview/preview-deep-dive/how-previews-work.md
+++ b/content/building-a-preview/preview-deep-dive/how-previews-work.md
@@ -12,137 +12,107 @@ weight: 1
 
 ## The build process: explained
 
-When you kick off a Preview build, Tugboat grabs the
-[config file](/setting-up-tugboat/create-a-tugboat-config-file/) from your
-linked repository. Tugboat follows the instructions to
-[set up each Service in your config file](/setting-up-services/how-to-set-up-services/),
-grabbing the specified Docker images and then executing the
-[Service Commands](/setting-up-services/how-to-set-up-services/leverage-service-commands)
+When you kick off a Preview build, Tugboat grabs the [config file](/setting-up-tugboat/create-a-tugboat-config-file/)
+from your linked repository. Tugboat follows the instructions to
+[set up each Service in your config file](/setting-up-services/how-to-set-up-services/), grabbing the specified Docker
+images and then executing the [Service Commands](/setting-up-services/how-to-set-up-services/leverage-service-commands)
 in three phases:
 
 1. `init`
 2. `update`
 3. `build`
 
-During the `init` phase, you might use commands that set up the basic preview
-infrastructure. This might include things like installing required packages or
-tools, or overriding default configuration files.
+During the `init` phase, you might use commands that set up the basic preview infrastructure. This might include things
+like installing required packages or tools, or overriding default configuration files.
 
-During the `update` phase, you might use commands that import data or other
-assets into a service. This might include things like importing a database, or
-syncing image files into a service.
+During the `update` phase, you might use commands that import data or other assets into a service. This might include
+things like importing a database, or syncing image files into a service.
 
-During the `build` phase, you might use commands that build or generate the
-actual site. This might include things like compiling Sass files, updating 3rd
-party libraries, or running database updates that the current code in the
-preview depends on.
+During the `build` phase, you might use commands that build or generate the actual site. This might include things like
+compiling Sass files, updating 3rd party libraries, or running database updates that the current code in the preview
+depends on.
 
 In the process of building your Preview, you'll
-[specify a default service](/setting-up-services/how-to-set-up-services/define-a-default-service/),
-and that's the service where your git repository is cloned. If you want to clone
-it into other services, see:
+[specify a default service](/setting-up-services/how-to-set-up-services/define-a-default-service/), and that's the
+service where your git repository is cloned. If you want to clone it into other services, see:
 [cloning git repositories into your Services](/setting-up-services/how-to-set-up-services/clone-git-repositories-into-your-services/).
 
-By the time the build is complete, Tugboat has configured Services according to
-your config file, including pulling the Docker images you want it to use for
-each Service, and has pulled in your code to execute your Preview.
+By the time the build is complete, Tugboat has configured Services according to your config file, including pulling the
+Docker images you want it to use for each Service, and has pulled in your code to execute your Preview.
 
 ### Why build phases matter
 
-When you're
-[changing](../../administer-previews/change-or-update-previews/#rebuild-previews)
-or
-[updating](../../administer-previews/change-or-update-previews/#refresh-previews)
-your Preview builds - or
-[building new Previews from a Base Preview](../../work-with-base-previews/building-new-previews/) -
-the build process may bypass some of the build phases. For example, when you
-Refresh a Preview, the build process pulls in updated code from your repo, but
-only executes Service commands from `update` and `build` - bypassing the `init`
-commands.
+When you're [changing](../../administer-previews/change-or-update-previews/#rebuild-previews) or
+[updating](../../administer-previews/change-or-update-previews/#refresh-previews) your Preview builds - or
+[building new Previews from a Base Preview](../../work-with-base-previews/building-new-previews/) - the build process
+may bypass some of the build phases. For example, when you Refresh a Preview, the build process pulls in updated code
+from your repo, but only executes Service commands from `update` and `build` - bypassing the `init` commands.
 
-This can get a little complicated, so we've made a handy-dandy flowchart to help
-you keep track of where various processes start in each build phase:
+This can get a little complicated, so we've made a handy-dandy flowchart to help you keep track of where various
+processes start in each build phase:
 
 ![Tugboat Build Phases](/_images/tugboat-build-phases.png)
 
 ## The Build Snapshot
 
-After your Tugboat Build completes, Tugboat commits the entire container, taking
-a snapshot of that container, including all of its data and Services, at that
-moment in time.
+After your Tugboat Build completes, Tugboat commits the entire container, taking a snapshot of that container, including
+all of its data and Services, at that moment in time.
 
 When you do things like:
 
 - [Clone a Preview](../../administer-previews/build-previews/#duplicate-a-preview)
 - [Reset a Preview](../../administer-previews/change-preview-states/#reset)
 
-Tugboat uses that build snapshot as the basis for those actions, enabling you to
-quickly duplicate a Preview build or reset a Preview build to the state it was
-in the moment the build completed.
+Tugboat uses that build snapshot as the basis for those actions, enabling you to quickly duplicate a Preview build or
+reset a Preview build to the state it was in the moment the build completed.
 
-{{% notice note %}} When Tugboat creates the build snapshot, the containers are
-fully stopped while the snapshot is taken, and then restarted again once the
-data is committed. If you try to implement a script that "sleeps" in the
-background while the Preview is being built, that process will not be present
-when the Preview restarts. {{% /notice %}}
+{{% notice note %}} When Tugboat creates the build snapshot, the containers are fully stopped while the snapshot is
+taken, and then restarted again once the data is committed. If you try to implement a script that "sleeps" in the
+background while the Preview is being built, that process will not be present when the Preview restarts. {{% /notice %}}
 
 ## How Base Previews work
 
-When you build a regular Preview, the
-[configuration file](/setting-up-tugboat/create-a-tugboat-config-file/)
-typically instructs Tugboat to pull in databases, image files, or other assets.
-This process can take a while; the larger the assets, the longer the build.
+When you build a regular Preview, the [configuration file](/setting-up-tugboat/create-a-tugboat-config-file/) typically
+instructs Tugboat to pull in databases, image files, or other assets. This process can take a while; the larger the
+assets, the longer the build.
 
-When you mark a Preview as a Base Preview, Tugboat uses that Preview's
-[build snapshot](#the-build-snapshot) as a starting point for every new Preview
-build. None of the new Previews need to re-download copies of databases, image
-files, or other assets. Base Previews can dramatically reduce the amount of time
-required to generate a working Preview.
+When you mark a Preview as a Base Preview, Tugboat uses that Preview's [build snapshot](#the-build-snapshot) as a
+starting point for every new Preview build. None of the new Previews need to re-download copies of databases, image
+files, or other assets. Base Previews can dramatically reduce the amount of time required to generate a working Preview.
 
-In addition to speeding up your Preview builds, Tugboat saves disk space by
-storing only a binary difference between the Base Preview and Previews built
-from that Base Preview. A new Preview only uses whatever space it needs that
-differs from the Base Preview. Often, this means a Base Preview might use 2-3GB
-of space, and a Preview built from it might only use 100-200MB. This is a great
-way to keep a Tugboat Project under your
-[billing tier's storage limit](/tugboat-billing/tugboat-pricing/#how-does-tugboat-pricing-work),
-even when you're building multiple Previews.
+In addition to speeding up your Preview builds, Tugboat saves disk space by storing only a binary difference between the
+Base Preview and Previews built from that Base Preview. A new Preview only uses whatever space it needs that differs
+from the Base Preview. Often, this means a Base Preview might use 2-3GB of space, and a Preview built from it might only
+use 100-200MB. This is a great way to keep a Tugboat Project under your
+[billing tier's storage limit](/tugboat-billing/tugboat-pricing/#how-does-tugboat-pricing-work), even when you're
+building multiple Previews.
 
-{{% notice tip %}} When you set a Base Preview, new Previews you build -
-including Previews that are built automatically from pull requests - use the
-Base Preview as a starting point, and build only from the `build` stage. This
-means that if you're making changes that would be processed during `init` or
-`update` stages, or changing a Docker image, you'll need to either
-[rebuild the Base Preview](../../work-with-base-previews/change-or-update/#change-a-base-preview),
-or
+{{% notice tip %}} When you set a Base Preview, new Previews you build - including Previews that are built automatically
+from pull requests - use the Base Preview as a starting point, and build only from the `build` stage. This means that if
+you're making changes that would be processed during `init` or `update` stages, or changing a Docker image, you'll need
+to either [rebuild the Base Preview](../../work-with-base-previews/change-or-update/#change-a-base-preview), or
 [build the Preview from scratch without the Base Preview](../../work-with-base-previews/building-new-previews/#build-a-preview-with-no-base-preview).
 {{% /notice %}}
 
 ## Preview size: explained
 
-What Tugboat calls "Preview size" is actually the size of the container in which
-the Preview lives. When a Preview is done building, Tugboat takes a snapshot of
-the container at that moment in time, and that's what you're seeing in your
+What Tugboat calls "Preview size" is actually the size of the container in which the Preview lives. When a Preview is
+done building, Tugboat takes a snapshot of the container at that moment in time, and that's what you're seeing in your
 Tugboat Dashboard.
 
-When you [set up Services](/setting-up-services/how-to-set-up-services/) in your
-Preview, Tugboat pulls those
-[Service images](/setting-up-services/how-to-set-up-services/specify-a-service-image)
-into the Preview container. Each of these Service images contributes to the
-total size of the Preview when it is fully built.
+When you [set up Services](/setting-up-services/how-to-set-up-services/) in your Preview, Tugboat pulls those
+[Service images](/setting-up-services/how-to-set-up-services/specify-a-service-image) into the Preview container. Each
+of these Service images contributes to the total size of the Preview when it is fully built.
 
-For example, say I'm building a Preview that uses Tugboat's Service images for
-`apache`, `mysql` and `redis`; those Service images are 154MB, 226MB, and 147MB
-at the time of this writing. That's over 500MB for these Services; by the time
-you add a database file, the container's operating system and other assets,
-you'll likely be looking at 800MB to 1GB for a Preview that's only pulling in
-100KB of code from your linked git repo.
+For example, say I'm building a Preview that uses Tugboat's Service images for `apache`, `mysql` and `redis`; those
+Service images are 154MB, 226MB, and 147MB at the time of this writing. That's over 500MB for these Services; by the
+time you add a database file, the container's operating system and other assets, you'll likely be looking at 800MB to
+1GB for a Preview that's only pulling in 100KB of code from your linked git repo.
 
-This is why working from a [Base Preview](#how-base-previews-work) is so helpful
-in reducing Preview size; all of those assets are contained in the Base Preview.
-When you build a new Preview from the Base Preview, the new Preview only
-contains what's different in the PR, Branch or Tag you're building. In my
-example above, a new Preview built from the Base Preview was only 20KB.
+This is why working from a [Base Preview](#how-base-previews-work) is so helpful in reducing Preview size; all of those
+assets are contained in the Base Preview. When you build a new Preview from the Base Preview, the new Preview only
+contains what's different in the PR, Branch or Tag you're building. In my example above, a new Preview built from the
+Base Preview was only 20KB.
 
 ## Preview status
 
@@ -154,75 +124,55 @@ Preview status is indicated in a couple of different ways:
 
 ### Color
 
-- {{% ui-text %}}Green:{{% /ui-text %}} Preview has built successfully and is
-  ready to view.
+- {{% ui-text %}}Green:{{% /ui-text %}} Preview has built successfully and is ready to view.
 - {{% ui-text %}}Yellow:{{% /ui-text %}} A Preview action is in progress.
-- {{% ui-text %}}Red:{{% /ui-text %}} Preview build has failed, or has been
-  stopped.
+- {{% ui-text %}}Red:{{% /ui-text %}} Preview build has failed, or has been stopped.
 
 ### Status message
 
-- {{% ui-text %}}Ready (and active):{{% /ui-text %}} When your Preview finishes
-  building successfully, you'll see a green `ready` status, with a green dot to
-  indicate that the Preview is active and ready to view. When you click the
+- {{% ui-text %}}Ready (and active):{{% /ui-text %}} When your Preview finishes building successfully, you'll see a
+  green `ready` status, with a green dot to indicate that the Preview is active and ready to view. When you click the
   link, you'll go directly to your site Preview.
-- {{% ui-text %}}Ready (and inactive):{{% /ui-text %}} After your Preview has
-  built and some time has passed, you'll see a green `ready` status, with a
-  green half-moon to indicate that the Preview is available, but is currently
-  suspended. When you go to the Preview link, you'll see a splash page while the
-  Preview starts running again, and then you'll be taken to your Preview. If you
-  don't want to wait through the splash page, you can go to the
-  {{% ui-text %}}Actions{{% /ui-text %}} drop-down next to the
-  {{% ui-text %}}Preview{{% /ui-text %}} button, and select
-  {{% ui-text %}}Start{{% /ui-text %}}; this will restart the Preview. When the
-  half-moon switches to a green dot, you'll be able to go directly to the
-  Preview, bypassing the splash screen.
-- {{% ui-text %}}Building:{{% /ui-text %}} While your Preview build is
-  in-progress, you'll see a `building` status in yellow. If your Preview build
-  is taking significantly longer than your average build time, displayed in the
-  Repository Stats section lower on the Project -> Repo page, you may want to
-  start [troubleshooting](/troubleshooting/).
-- {{% ui-text %}}Rebuilding:{{% /ui-text %}} When a rebuild has been kicked off,
-  you'll see a `rebuilding` status in yellow. This indicates a complete Preview
-  rebuild from the beginning of the build process, so it should take as long as
-  a typical build.
-- {{% ui-text %}}Refreshing:{{% /ui-text %}} When a refresh has been kicked off,
-  you'll see a `refreshing` status in yellow. This indicates a Preview that is
-  pulling in the latest code from git, and then running any commands in the
+- {{% ui-text %}}Ready (and inactive):{{% /ui-text %}} After your Preview has built and some time has passed, you'll see
+  a green `ready` status, with a green half-moon to indicate that the Preview is available, but is currently suspended.
+  When you go to the Preview link, you'll see a splash page while the Preview starts running again, and then you'll be
+  taken to your Preview. If you don't want to wait through the splash page, you can go to the
+  {{% ui-text %}}Actions{{% /ui-text %}} drop-down next to the {{% ui-text %}}Preview{{% /ui-text %}} button, and select
+  {{% ui-text %}}Start{{% /ui-text %}}; this will restart the Preview. When the half-moon switches to a green dot,
+  you'll be able to go directly to the Preview, bypassing the splash screen.
+- {{% ui-text %}}Building:{{% /ui-text %}} While your Preview build is in-progress, you'll see a `building` status in
+  yellow. If your Preview build is taking significantly longer than your average build time, displayed in the Repository
+  Stats section lower on the Project -> Repo page, you may want to start [troubleshooting](/troubleshooting/).
+- {{% ui-text %}}Rebuilding:{{% /ui-text %}} When a rebuild has been kicked off, you'll see a `rebuilding` status in
+  yellow. This indicates a complete Preview rebuild from the beginning of the build process, so it should take as long
+  as a typical build.
+- {{% ui-text %}}Refreshing:{{% /ui-text %}} When a refresh has been kicked off, you'll see a `refreshing` status in
+  yellow. This indicates a Preview that is pulling in the latest code from git, and then running any commands in the
   `update` section, followed by the `build` section of the
   [Configuration file](/setting-up-tugboat/create-a-tugboat-config-file/).
-- {{% ui-text %}}Resuming:{{% /ui-text %}} When you've used the Action -> Start
-  option, you'll see a `resuming` status in yellow while the Preview starts
-  spinning up [services](/setting-up-services/) again.
-- {{% ui-text %}}Stopping:{{% /ui-text %}} When you've used the Action -> Stop
-  option, you'll see a `stopping` status in yellow while the Preview goes
-  through the process of stopping [services](/setting-up-services/).
-- {{% ui-text %}}Stopped:{{% /ui-text %}} When you've used the Action -> Stop
-  option, you'll see a `stopped` status in red to indicate that the Preview has
-  successfully stopped [services](/setting-up-services/).
-- {{% ui-text %}}Suspended{{% /ui-text %}} - When Previews have been inactive
-  for a period of time, you'll see a `suspended` status. Any incoming HTTP
-  request to the preview will automatically start it again.
-- {{% ui-text %}}Failed:{{% /ui-text %}} When something goes wrong during the
-  the last action that was taken on the Preview, you'll see a `failed` status in
-  red. Details should be available in the Preview's activity logs. Sometimes a
-  failed Preview can be recovered by resetting it. For more help with a `failed`
-  preview, take a look at our [troubleshooting](/troubleshooting/) docs, or go
-  to our [Help and Support](/support/) page to join our Slack support channel or
-  email us.
-- {{% ui-text %}}Unavailable{{% /ui-text %}} - When something goes wrong trying
-  to load the Preview, you may see an `unavailable` status. This usually
-  indicates an internal Tugboat error.
-  [Resetting](../../administer-previews/change-preview-states/#reset) a Preview
-  often fixes this.
-- {{% ui-text %}}Canceled{{% /ui-text %}} - When you cancel a Preview while it's
-  building, you'll see a `canceled` status in red.
+- {{% ui-text %}}Resuming:{{% /ui-text %}} When you've used the Action -> Start option, you'll see a `resuming` status
+  in yellow while the Preview starts spinning up [services](/setting-up-services/) again.
+- {{% ui-text %}}Stopping:{{% /ui-text %}} When you've used the Action -> Stop option, you'll see a `stopping` status in
+  yellow while the Preview goes through the process of stopping [services](/setting-up-services/).
+- {{% ui-text %}}Stopped:{{% /ui-text %}} When you've used the Action -> Stop option, you'll see a `stopped` status in
+  red to indicate that the Preview has successfully stopped [services](/setting-up-services/).
+- {{% ui-text %}}Suspended{{% /ui-text %}} - When Previews have been inactive for a period of time, you'll see a
+  `suspended` status. Any incoming HTTP request to the preview will automatically start it again.
+- {{% ui-text %}}Failed:{{% /ui-text %}} When something goes wrong during the the last action that was taken on the
+  Preview, you'll see a `failed` status in red. Details should be available in the Preview's activity logs. Sometimes a
+  failed Preview can be recovered by resetting it. For more help with a `failed` preview, take a look at our
+  [troubleshooting](/troubleshooting/) docs, or go to our [Help and Support](/support/) page to join our Slack support
+  channel or email us.
+- {{% ui-text %}}Unavailable{{% /ui-text %}} - When something goes wrong trying to load the Preview, you may see an
+  `unavailable` status. This usually indicates an internal Tugboat error.
+  [Resetting](../../administer-previews/change-preview-states/#reset) a Preview often fixes this.
+- {{% ui-text %}}Canceled{{% /ui-text %}} - When you cancel a Preview while it's building, you'll see a `canceled`
+  status in red.
 
 ### Service states
 
 A Service could be in any of the above states, as well as:
 
-- {{% ui-text %}}Committing{{% /ui-text %}} - Tugboat is taking a snapshot of
-  the current state of the Service.
-- {{% ui-text %}}Waiting{{% /ui-text %}} - Tugboat is performing some operation
-  on the Service's repo, and the Service is waiting for its turn.
+- {{% ui-text %}}Committing{{% /ui-text %}} - Tugboat is taking a snapshot of the current state of the Service.
+- {{% ui-text %}}Waiting{{% /ui-text %}} - Tugboat is performing some operation on the Service's repo, and the Service
+  is waiting for its turn.

--- a/content/building-a-preview/preview-deep-dive/inside-a-preview.md
+++ b/content/building-a-preview/preview-deep-dive/inside-a-preview.md
@@ -13,9 +13,8 @@ When you click into a Preview, you'll find a few different things:
 
 ## Services
 
-One of the first things you'll see inside a Preview is a list of all Services
-running in that Preview, as well as information about each of these services.
-From here, you can:
+One of the first things you'll see inside a Preview is a list of all Services running in that Preview, as well as
+information about each of these services. From here, you can:
 
 - Determine which Service is the
   [Default Service](/setting-up-services/how-to-set-up-services/define-a-default-service/)
@@ -27,33 +26,26 @@ From here, you can:
 
 ### Click into Services to view build and output logs
 
-When you click into the Service name, you're drilling into that Service's
-details. You'll see the Service Build Log and Service Output, giving you greater
-insight into what's happening within your Services. This can be useful when
-you're troubleshooting an issue with a Preview Build.
+When you click into the Service name, you're drilling into that Service's details. You'll see the Service Build Log and
+Service Output, giving you greater insight into what's happening within your Services. This can be useful when you're
+troubleshooting an issue with a Preview Build.
 
 ![Click into Services to view logs](/_images/inside-a-preview-service-build-and-output-logs.png)
 
 ### Using the Preview Action inside a Service
 
-When a Service has an exposed port, you'll see a clickable
-{{% ui-text %}}Preview{{% /ui-text %}} link for that Service. Clicking the
-{{% ui-text %}}Preview{{% /ui-text %}} link takes you into what that Service is
+When a Service has an exposed port, you'll see a clickable {{% ui-text %}}Preview{{% /ui-text %}} link for that Service.
+Clicking the {{% ui-text %}}Preview{{% /ui-text %}} link takes you into what that Service is doing.
+
+The [`default` service](/setting-up-services/how-to-set-up-services/define-a-default-service/) always has an exposed
+port, so you'll always have the option to Preview that Service. If that is the only Service that has an exposed port -
+i.e. it's the only Service with the {{% ui-text %}}Preview{{% /ui-text %}} link - what you'll see is the same as
+clicking the blue {{% ui-text %}}Preview{{% /ui-text %}} button.
+
+If you manually [expose a port](/setting-up-services/how-to-set-up-services/expose-a-service-http-port/) in a Service
+that isn't the `default`, you'll see the Preview option for that Service, too. Clicking into a
+{{% ui-text %}}Preview{{% /ui-text %}} link for a Service that isn't the _default_ shows you only what that Service is
 doing.
-
-The
-[`default` service](/setting-up-services/how-to-set-up-services/define-a-default-service/)
-always has an exposed port, so you'll always have the option to Preview that
-Service. If that is the only Service that has an exposed port - i.e. it's the
-only Service with the {{% ui-text %}}Preview{{% /ui-text %}} link - what you'll
-see is the same as clicking the blue {{% ui-text %}}Preview{{% /ui-text %}}
-button.
-
-If you manually
-[expose a port](/setting-up-services/how-to-set-up-services/expose-a-service-http-port/)
-in a Service that isn't the `default`, you'll see the Preview option for that
-Service, too. Clicking into a {{% ui-text %}}Preview{{% /ui-text %}} link for a
-Service that isn't the _default_ shows you only what that Service is doing.
 
 ![Preview inside a Service](/_images/inside-a-preview-preview-action.png)
 
@@ -68,60 +60,50 @@ Starting a terminal inside a Service gives you two awesome abilities:
 
 #### Tugboat as an on-demand development environment
 
-Imagine one of your colleagues is working on a new feature, and comes to you for
-help because you know more about using `npm`. You don't have the code installed
-locally, and it can be a hassle to replicate a colleague's local. Instead, you
-can spin up a Tugboat Preview Build that uses your colleague's code, and
-terminal directly into `apache` to team up with your colleague - developing
-right in the container. Speed up development, and take local configuration
-questions out of the equation.
+Imagine one of your colleagues is working on a new feature, and comes to you for help because you know more about using
+`npm`. You don't have the code installed locally, and it can be a hassle to replicate a colleague's local. Instead, you
+can spin up a Tugboat Preview Build that uses your colleague's code, and terminal directly into `apache` to team up with
+your colleague - developing right in the container. Speed up development, and take local configuration questions out of
+the equation.
 
 #### Direct Preview Build troubleshooting from within a Service
 
-Isn't it frustrating when a CI build fails, but you don't have a good way to
-find out what went wrong? If you're comfortable debugging on the command line,
-you can open a terminal directly into your Services to
+Isn't it frustrating when a CI build fails, but you don't have a good way to find out what went wrong? If you're
+comfortable debugging on the command line, you can open a terminal directly into your Services to
 [troubleshoot](/troubleshooting/) and test fixes for Tugboat Build failures.
 
 ## Preview log
 
-In the Preview log section, you'll see a build log for your Preview build. The
-Preview Log pane may not show the entirety of the log; if you've got a complex
-build, you may need to click {{% ui-text %}}See Full Log{{% /ui-text %}} to find
-and diagnose something early in your Preview build.
+In the Preview log section, you'll see a build log for your Preview build. The Preview Log pane may not show the
+entirety of the log; if you've got a complex build, you may need to click {{% ui-text %}}See Full Log{{% /ui-text %}} to
+find and diagnose something early in your Preview build.
 
 ![View the Preview Log](/_images/inside-a-preview-log.png)
 
-These logs differ from the Service logs in that these logs reflect _all_ the
-commands in your Preview build, while the Service logs dive deep into the build
-and output of Services but each log details only that Service. When using the
-logs for troubleshooting, you may want to start with the Preview log to
-determine where something went wrong, and then you may dive into that Service's
-log to dig deeper.
+These logs differ from the Service logs in that these logs reflect _all_ the commands in your Preview build, while the
+Service logs dive deep into the build and output of Services but each log details only that Service. When using the logs
+for troubleshooting, you may want to start with the Preview log to determine where something went wrong, and then you
+may dive into that Service's log to dig deeper.
 
 ## Captured mail
 
-If you're using a Tugboat-provided image, outgoing email generated within your
-Preview should forward to our SMTP proxy. Tugboat captures that outgoing email,
-and displays it in Captured Mail when you click into a Preview. This makes it
+If you're using a Tugboat-provided image, outgoing email generated within your Preview should forward to our SMTP proxy.
+Tugboat captures that outgoing email, and displays it in Captured Mail when you click into a Preview. This makes it
 possible for you to verify that email is sending as expected.
 
-Tugboat-provided images send outbound email through the Tugboat SMTP proxy by
-default. If you are using your own image, or your codebase does not use the
-underlying operating system mail configuration, use the \$TUGBOAT_SMTP
-[Environment Variable](/reference/environment-variables/#tugboat-environment-variables)
-to ensure that Tugboat is able to properly capture your outbound email.
+Tugboat-provided images send outbound email through the Tugboat SMTP proxy by default. If you are using your own image,
+or your codebase does not use the underlying operating system mail configuration, use the \$TUGBOAT_SMTP
+[Environment Variable](/reference/environment-variables/#tugboat-environment-variables) to ensure that Tugboat is able
+to properly capture your outbound email.
 
-{{% notice warning %}} Tugboat makes a best-effort attempt at capturing outbound
-email. Commonly used outbound SMTP ports (25, 465, 587, and 2525) are blocked,
-and any mail sent through the Tugboat SMTP proxy is captured for display with
-the Preview that sent it. {{% /notice %}}
+{{% notice warning %}} Tugboat makes a best-effort attempt at capturing outbound email. Commonly used outbound SMTP
+ports (25, 465, 587, and 2525) are blocked, and any mail sent through the Tugboat SMTP proxy is captured for display
+with the Preview that sent it. {{% /notice %}}
 
 ## Visual Diffs
 
-When you're using Visual Diffs with your Previews, you'll click into the Preview
-to view them. Visual Diffs are a great tool to visualize site changes, and it's
-an easy way to spot visual regression.
+When you're using Visual Diffs with your Previews, you'll click into the Preview to view them. Visual Diffs are a great
+tool to visualize site changes, and it's an easy way to spot visual regression.
 
 ![Scroll down to view Visual Diffs](/_images/visual-diffs-scroll-to-view-visual-diffs.png)
 

--- a/content/building-a-preview/preview-deep-dive/optimize-preview-builds.md
+++ b/content/building-a-preview/preview-deep-dive/optimize-preview-builds.md
@@ -4,9 +4,8 @@ date: 2019-09-19T10:22:22-04:00
 weight: 8
 ---
 
-Do your Previews take a long time to build? Some things, like importing large
-assets, are going to take time - but there are some things you can do to speed
-up your Preview builds:
+Do your Previews take a long time to build? Some things, like importing large assets, are going to take time - but there
+are some things you can do to speed up your Preview builds:
 
 - [Use Service Commands to create a Base Preview that does the heavy lifting](#use-service-commands-to-create-a-base-preview-that-does-the-heavy-lifting)
 - [Use the Auto Refresh Base Preview functionality to update large assets](#use-the-auto-refresh-base-preview-functionality-to-update-large-assets)
@@ -16,35 +15,27 @@ up your Preview builds:
 
 ## Use Service Commands to create a Base Preview that does the heavy lifting
 
-The big value of using a Base Preview is that you can front-load the work into a
-time-consuming Preview you only have to build once, and then use that as a base
-to iterate on with smaller, faster-building Previews.
+The big value of using a Base Preview is that you can front-load the work into a time-consuming Preview you only have to
+build once, and then use that as a base to iterate on with smaller, faster-building Previews.
 
-You can do this by using
-[Service Commands](/setting-up-services/how-to-set-up-services/leverage-service-commands/)
-in the `init` stage of the Preview build to do the resource-intensive,
-time-intensive processes - and then
-[set that as your Base Preview](../../work-with-base-previews/set-a-base-preview/)
-so you don't have to complete those steps in every single build. This is the
-perfect time to install a large database that you won't have to update in
-subsequent Previews, or download and configure the host of
-[services](/setting-up-services/) in your Preview.
+You can do this by using [Service Commands](/setting-up-services/how-to-set-up-services/leverage-service-commands/) in
+the `init` stage of the Preview build to do the resource-intensive, time-intensive processes - and then
+[set that as your Base Preview](../../work-with-base-previews/set-a-base-preview/) so you don't have to complete those
+steps in every single build. This is the perfect time to install a large database that you won't have to update in
+subsequent Previews, or download and configure the host of [services](/setting-up-services/) in your Preview.
 
 ## Use the Auto Refresh Base Preview functionality to update large assets
 
-If you're updating large assets as part of the `update` stage of your Tugboat
-build, you can configure Tugboat to
+If you're updating large assets as part of the `update` stage of your Tugboat build, you can configure Tugboat to
 [automatically refresh your Base Preview](/setting-up-tugboat/select-repo-settings/#refresh-base-previews-automatically)
-while your crew isn't working. By default, Tugboat automatically refreshes Base
-Previews daily at 12am UTC. You can set this for a time and frequency that works
-best for your team, and then you won't have to manually update your Base Preview
-when you're about to test an important build - it will already have the latest
-database, or any large assets you need, whenever you're ready.
+while your crew isn't working. By default, Tugboat automatically refreshes Base Previews daily at 12am UTC. You can set
+this for a time and frequency that works best for your team, and then you won't have to manually update your Base
+Preview when you're about to test an important build - it will already have the latest database, or any large assets you
+need, whenever you're ready.
 
 ## Optimizing Preview size
 
-If you want to make your Previews smaller, there are a couple of tricks you can
-use to reduce Preview size:
+If you want to make your Previews smaller, there are a couple of tricks you can use to reduce Preview size:
 
 - [Use a Base Preview](#work-from-base-previews)
 - [Use dummy data](#use-dummy-data)
@@ -54,42 +45,34 @@ Looking for more info about Preview size? Check out:
 
 ### Work From Base Previews
 
-In addition to speeding up Preview builds, Base Previews can help you
-dramatically reduce the size of Previews built from that Base Preview. This is
-because the Base Preview contains everything Tugboat needs to run your Preview,
-while subsequent Previews only contain the differences between the Base Preview
-and the new Preview build.
+In addition to speeding up Preview builds, Base Previews can help you dramatically reduce the size of Previews built
+from that Base Preview. This is because the Base Preview contains everything Tugboat needs to run your Preview, while
+subsequent Previews only contain the differences between the Base Preview and the new Preview build.
 
-In practice, this means that a Base Preview might be 3GB in size, but subsequent
-Previews might be only 100MB.
+In practice, this means that a Base Preview might be 3GB in size, but subsequent Previews might be only 100MB.
 
 Ready to set up a Base Preview? Check out:
 [How to set a Base Preview](../../work-with-base-previews/set-a-base-preview/).
 
 ### Use dummy data
 
-Are you pulling in a large production database? You can save Preview space -
-_and_ speed up your Preview builds at the same time - by switching to a small
-dummy database that contains enough data for testing, but doesn't mirror your
-large production behemoth.
+Are you pulling in a large production database? You can save Preview space - _and_ speed up your Preview builds at the
+same time - by switching to a small dummy database that contains enough data for testing, but doesn't mirror your large
+production behemoth.
 
 ## Contact Tugboat support for help optimizing your Config file
 
-Sometimes, speeding up your Preview builds might involve having a second set of
-eyes take a look at your Config file and make recommendations to help you
-optimize it. This might include something like running a command in `init`
-instead of `update`, or scripting a few commands. The team at Tugboat is happy
-to help; our [Support](/support/) page can direct you to our Tugboat support
-Slack, or an email address where you can reach us.
+Sometimes, speeding up your Preview builds might involve having a second set of eyes take a look at your Config file and
+make recommendations to help you optimize it. This might include something like running a command in `init` instead of
+`update`, or scripting a few commands. The team at Tugboat is happy to help; our [Support](/support/) page can direct
+you to our Tugboat support Slack, or an email address where you can reach us.
 
 ## Upgrade your project tier to a higher-performance tier
 
-If it's not a question of optimizing your Config file - for example, if you're
-building a complex or resource-intensive sequence of code in every Tugboat
-Preview - you might want to consider upgrading your Tugboat Project to a
-higher-performance tier. A higher-performance tier gives you more CPU power and
-RAM to build your Previews, which can mildly or dramatically speed up your build
-times. When build times matter, keep this option in mind.
+If it's not a question of optimizing your Config file - for example, if you're building a complex or resource-intensive
+sequence of code in every Tugboat Preview - you might want to consider upgrading your Tugboat Project to a
+higher-performance tier. A higher-performance tier gives you more CPU power and RAM to build your Previews, which can
+mildly or dramatically speed up your build times. When build times matter, keep this option in mind.
 
 You can
 [change your Tugboat plan in {{% ui-text %}}Project Settings{{% /ui-text %}}](/tugboat-billing/change-tugboat-plan).

--- a/content/building-a-preview/share-a-preview/auto-share-url.md
+++ b/content/building-a-preview/share-a-preview/auto-share-url.md
@@ -4,36 +4,28 @@ date: 2019-09-24T11:56:56-04:00
 weight: 3
 ---
 
-When you're using the Tugboat integration with
-[GitHub](/setting-up-tugboat/connect-with-your-provider/#github),
+When you're using the Tugboat integration with [GitHub](/setting-up-tugboat/connect-with-your-provider/#github),
 [GitLab](/setting-up-tugboat/connect-with-your-provider/#gitlab) or
-[BitBucket](/setting-up-tugboat/connect-with-your-provider/#bitbucket), you can
-configure Tugboat to automatically post links to Previews as comments on pull
-requests.
+[BitBucket](/setting-up-tugboat/connect-with-your-provider/#bitbucket), you can configure Tugboat to automatically post
+links to Previews as comments on pull requests.
 
 ### To configure Tugboat to automatically post Preview links:
 
-1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-   upper-right of the Tugboat screen.
+1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 2. Select the project where you want Tugboat to auto-post Preview links.
 3. Click into {{% ui-text %}}Settings{{% /ui-text %}} for the repository.
-4. Click the checkbox for {{% ui-text %}}Post Preview Links in Pull Request
-   Comments{{% /ui-text %}} .
-5. Press the {{% ui-text %}}Save Configuration{{% /ui-text %}} button to save
-   your changes.
+4. Click the checkbox for {{% ui-text %}}Post Preview Links in Pull Request Comments{{% /ui-text %}} .
+5. Press the {{% ui-text %}}Save Configuration{{% /ui-text %}} button to save your changes.
 
-{{% notice note %}} By default, Tugboat's comments to a linked git provider
-display as the person who linked the provider to Tugboat. That means the person
-who linked the repo will get notifications for every PR where Tugboat
-automatically posts a comment. If this person does not wish to receive
-notifications, you can
-[configure a Tugboat bot](/administer-tugboat-crew/user-admin/#add-a-tugboat-bot-to-your-team)
-to post the comments and receive those notifications. {{% /notice %}}
+{{% notice note %}} By default, Tugboat's comments to a linked git provider display as the person who linked the
+provider to Tugboat. That means the person who linked the repo will get notifications for every PR where Tugboat
+automatically posts a comment. If this person does not wish to receive notifications, you can
+[configure a Tugboat bot](/administer-tugboat-crew/user-admin/#add-a-tugboat-bot-to-your-team) to post the comments and
+receive those notifications. {{% /notice %}}
 
 {{%expand "Visual Walkthrough" %}}
 
-Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-upper-right of the Tugboat screen.
+Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 
 ![Go to username -> My Projects](/_images/go-to-user-my-projects.png)
 
@@ -45,13 +37,11 @@ Click into {{% ui-text %}}Settings{{% /ui-text %}} for the repository.
 
 ![Go to Repository Settings](/_images/go-to-repository-settings.png)
 
-Click the checkbox for {{% ui-text %}}Post Preview Links in Pull Request
-Comments{{% /ui-text %}} .
+Click the checkbox for {{% ui-text %}}Post Preview Links in Pull Request Comments{{% /ui-text %}} .
 
 ![Click the checkbox next to Post Preview Links in Pull Request Comments](/_images/share-preview-post-preview-links-in-pull-request-comments.png)
 
-Press the {{% ui-text %}}Save Configuration{{% /ui-text %}} button to save your
-changes.
+Press the {{% ui-text %}}Save Configuration{{% /ui-text %}} button to save your changes.
 
 ![Press the Save Configuration button](/_images/share-preview-repo-settings-save-configuration.png)
 

--- a/content/building-a-preview/share-a-preview/manually-share-url.md
+++ b/content/building-a-preview/share-a-preview/manually-share-url.md
@@ -8,24 +8,19 @@ Want to share a Preview link manually with Lisa in Product, or Dan the client?
 
 ### To manually get the link to a Preview you want to share:
 
-1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-   upper-right of the Tugboat screen.
+1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 2. Select the project that contains the Preview you want to share.
 3. Click the name of the repo that contains the Preview you want to share.
-4. Go to the Preview you want to share, and either open the Preview and copy the
-   URL from the browser's address bar, or use the browser options to Copy Link
-   on the {{% ui-text %}}Preview{{% /ui-text %}} button.
+4. Go to the Preview you want to share, and either open the Preview and copy the URL from the browser's address bar, or
+   use the browser options to Copy Link on the {{% ui-text %}}Preview{{% /ui-text %}} button.
 
-Send that link to the person who needs to look at the Preview, and they'll be
-able to view it. Tugboat links are hard-to-guess secure URLs that are accessible
-to anyone with the link; that person doesn't need to be a member of your
-[Tugboat crew](/administer-tugboat-crew/user-admin/), or able to view the git
-repo where the code is hosted.
+Send that link to the person who needs to look at the Preview, and they'll be able to view it. Tugboat links are
+hard-to-guess secure URLs that are accessible to anyone with the link; that person doesn't need to be a member of your
+[Tugboat crew](/administer-tugboat-crew/user-admin/), or able to view the git repo where the code is hosted.
 
 {{%expand "Visual Walkthrough" %}}
 
-Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-upper-right of the Tugboat screen.
+Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 
 ![Go to username -> My Projects](/_images/go-to-user-my-projects.png)
 
@@ -37,9 +32,8 @@ Click the name of the repo that contains the Preview you want to share.
 
 ![Click into Tugboat repository](/_images/click-into-tugboat-repository.png)
 
-Go to the Preview you want to share, and either open the Preview and copy the
-URL from the browser's address bar, or use the browser options to Copy Link on
-the {{% ui-text %}}Preview{{% /ui-text %}} button.
+Go to the Preview you want to share, and either open the Preview and copy the URL from the browser's address bar, or use
+the browser options to Copy Link on the {{% ui-text %}}Preview{{% /ui-text %}} button.
 
 ![Manually share Preview](/_images/manually-share-preview.png)
 

--- a/content/building-a-preview/work-with-base-previews/_index.md
+++ b/content/building-a-preview/work-with-base-previews/_index.md
@@ -10,8 +10,8 @@ pre = "<b></b>"
 
 # Using Base Previews
 
-To speed up your Preview builds, and reduce subsequent Preview builds to smaller
-files, set a Base Preview as a starting point for child Previews.
+To speed up your Preview builds, and reduce subsequent Preview builds to smaller files, set a Base Preview as a starting
+point for child Previews.
 
 {{% children  %}}
 

--- a/content/building-a-preview/work-with-base-previews/building-new-previews.md
+++ b/content/building-a-preview/work-with-base-previews/building-new-previews.md
@@ -4,19 +4,16 @@ date: 2019-09-24T11:55:35-04:00
 weight: 9
 ---
 
-When you're building Previews after you've set a Base Preview, those Preview
-builds are child builds of the Base Preview. They use the Base Preview's
-[build snapshot](../../preview-deep-dive/how-previews-work/#the-build-snapshot)
-for things like setting up Services, including pulling Docker images, and
-pulling in any assets that are imported during the `init` or `update` phase of
-the Base Preview build.
+When you're building Previews after you've set a Base Preview, those Preview builds are child builds of the Base
+Preview. They use the Base Preview's [build snapshot](../../preview-deep-dive/how-previews-work/#the-build-snapshot) for
+things like setting up Services, including pulling Docker images, and pulling in any assets that are imported during the
+`init` or `update` phase of the Base Preview build.
 
-When you're working with Previews that are child Previews of a Base Preview,
-Build and Rebuild start from the `build` phase, bypassing the `init` and
-`refresh` phases of a build. This includes:
+When you're working with Previews that are child Previews of a Base Preview, Build and Rebuild start from the `build`
+phase, bypassing the `init` and `refresh` phases of a build. This includes:
 
-- [Manual Preview Builds](../../administer-previews/build-previews/#manually-build-a-preview)
-  (when you do not specify building from scratch)
+- [Manual Preview Builds](../../administer-previews/build-previews/#manually-build-a-preview) (when you do not specify
+  building from scratch)
 - [Previews that are automatically built from pull requests](../../automate-previews/auto-generate).
 - [Rebuilding child Previews](../../administer-previews/change-or-update-previews/#rebuild-previews)
 - [Rebuild orphaned Previews automatically](../../../setting-up-tugboat/select-repo-settings/#rebuild-orphaned-previews-automatically)
@@ -24,30 +21,25 @@ Build and Rebuild start from the `build` phase, bypassing the `init` and
 For more info on build phases, see:
 [the build process: explained](../../preview-deep-dive/how-previews-work/#the-build-process-explained).
 
-After you've set a Base Preview, you do have one option to build new Previews
-that do not use the Base Preview: manually build a Preview from scratch. A
-Preview built this way is not a child Preview, and behaves like a typical
-Preview when Building or Rebuilding.
+After you've set a Base Preview, you do have one option to build new Previews that do not use the Base Preview: manually
+build a Preview from scratch. A Preview built this way is not a child Preview, and behaves like a typical Preview when
+Building or Rebuilding.
 
 ## Build a Preview with no Base Preview
 
 To manually build a Preview with no Base Preview:
 
-1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-   upper-right of the Tugboat screen.
+1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 2. Select the project where you want to build a Preview.
 3. Click into the repo where you want to build a Preview.
-4. Go to the {{% ui-text %}}Available to Build{{% /ui-text %}} section of the
-   Repository Dashboard.
-5. Click into the drop-down next to the {{% ui-text %}}Build
-   Preview{{% /ui-text %}} button for the Preview you'd like to build from
-   scratch.
+4. Go to the {{% ui-text %}}Available to Build{{% /ui-text %}} section of the Repository Dashboard.
+5. Click into the drop-down next to the {{% ui-text %}}Build Preview{{% /ui-text %}} button for the Preview you'd like
+   to build from scratch.
 6. Select the {{% ui-text %}}Build with no base preview{{% /ui-text %}} option.
 
 {{%expand "Visual Walkthrough" %}}
 
-Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-upper-right of the Tugboat screen.
+Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 
 ![Go to username -> My Projects](/_images/go-to-user-my-projects.png)
 
@@ -59,13 +51,12 @@ Click into the repo where you want to build a Preview.
 
 ![Click into Tugboat repository](/_images/click-into-tugboat-repository.png)
 
-Go to the {{% ui-text %}}Available to Build{{% /ui-text %}} section of the
-Repository Dashboard.
+Go to the {{% ui-text %}}Available to Build{{% /ui-text %}} section of the Repository Dashboard.
 
 ![Scroll to Available to Build](/_images/scroll-to-available-to-build.png)
 
-Click into the drop-down next to the {{% ui-text %}}Build
-Preview{{% /ui-text %}} button for the Preview you'd like to build from scratch.
+Click into the drop-down next to the {{% ui-text %}}Build Preview{{% /ui-text %}} button for the Preview you'd like to
+build from scratch.
 
 ![Go to the Build Preview drop-down menu](/_images/go-to-build-preview-drop-down.png)
 

--- a/content/building-a-preview/work-with-base-previews/change-or-update.md
+++ b/content/building-a-preview/work-with-base-previews/change-or-update.md
@@ -11,39 +11,33 @@ There are a few different ways you can change or update your Base Previews:
 
 ## Change a Base Preview
 
-If you want to change a Docker image that a Base Preview is using, or make
-changes to something that happens during the `init` phase of the Preview build
-process, you'll need to Rebuild your Base Preview. Rebuilding a Base Preview
-kicks off a fresh build process from the beginning, in effect replacing your
-current Base Preview with a new one that contains all of your changes.
+If you want to change a Docker image that a Base Preview is using, or make changes to something that happens during the
+`init` phase of the Preview build process, you'll need to Rebuild your Base Preview. Rebuilding a Base Preview kicks off
+a fresh build process from the beginning, in effect replacing your current Base Preview with a new one that contains all
+of your changes.
 
 Want to know more about build phases? Check out:
 [the build process: explained](../../preview-deep-dive/how-previews-work/#the-build-process-explained).
 
-{{% notice note %}} If you've checked the
-[Repository Setting](/setting-up-tugboat/select-repo-settings/) to **Rebuild
-Orphaned Previews Automatically**, a successful Rebuild of a Base Preview will
-kick off Rebuilds of any child Previews that were built from your Base Preview.
-{{% /notice %}}
+{{% notice note %}} If you've checked the [Repository Setting](/setting-up-tugboat/select-repo-settings/) to **Rebuild
+Orphaned Previews Automatically**, a successful Rebuild of a Base Preview will kick off Rebuilds of any child Previews
+that were built from your Base Preview. {{% /notice %}}
 
 ### To Rebuild a Base Preview:
 
-1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-   upper-right of the Tugboat screen.
+1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 2. Select the project where you want to change the Base Preview.
 3. Click the name of the repo that contains Base Preview you want to change.
-4. Click the {{% ui-text %}}Actions{{% /ui-text %}} drop-down menu for the Base
-   Preview, and select {{% ui-text %}}Rebuild{{% /ui-text %}} .
-5. To confirm that you actually want to change the Base Preview, rather than
-   just updating it, click the checkbox next to {{% ui-text %}}Yes, rebuild this
-   preview{{% /ui-text %}} . You may also want to {{% ui-text %}}Rebuild
-   previews built from this one when finished{{% /ui-text %}} .
+4. Click the {{% ui-text %}}Actions{{% /ui-text %}} drop-down menu for the Base Preview, and select
+   {{% ui-text %}}Rebuild{{% /ui-text %}} .
+5. To confirm that you actually want to change the Base Preview, rather than just updating it, click the checkbox next
+   to {{% ui-text %}}Yes, rebuild this preview{{% /ui-text %}} . You may also want to {{% ui-text %}}Rebuild previews
+   built from this one when finished{{% /ui-text %}} .
 6. Press the {{% ui-text %}}Rebuild{{% /ui-text %}} button.
 
 {{%expand "Visual Walkthrough" %}}
 
-Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-upper-right of the Tugboat screen.
+Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 
 ![Go to username -> My Projects](/_images/go-to-user-my-projects.png)
 
@@ -55,15 +49,14 @@ Click the name of the repo that contains Base Preview you want to change.
 
 ![Click into Tugboat repository](/_images/click-into-tugboat-repository.png)
 
-Click the {{% ui-text %}}Actions{{% /ui-text %}} drop-down menu for the Base
-Preview, and select {{% ui-text %}}Rebuild{{% /ui-text %}} .
+Click the {{% ui-text %}}Actions{{% /ui-text %}} drop-down menu for the Base Preview, and select
+{{% ui-text %}}Rebuild{{% /ui-text %}} .
 
 ![Click the Actions drop-down, and select Rebuild.](/_images/base-preview-actions-rebuild.png)
 
-To confirm that you actually want to change the Base Preview, rather than just
-updating it, click the checkbox next to {{% ui-text %}}Yes, rebuild this
-preview{{% /ui-text %}} . You may also want to {{% ui-text %}}Rebuild previews
-built from this one when finished{{% /ui-text %}} .
+To confirm that you actually want to change the Base Preview, rather than just updating it, click the checkbox next to
+{{% ui-text %}}Yes, rebuild this preview{{% /ui-text %}} . You may also want to {{% ui-text %}}Rebuild previews built
+from this one when finished{{% /ui-text %}} .
 
 ![Confirm Rebuild Previews built from this Base Preview after Rebuild](/_images/base-preview-rebuild-previews-from-base-after-rebuild.png)
 
@@ -75,10 +68,9 @@ Press the {{% ui-text %}}Rebuild{{% /ui-text %}} button.
 
 ## Update a Base Preview
 
-If you don't need to pull a new Docker image or make changes to the `init` phase
-in your [config file](/setting-up-tugboat/create-a-tugboat-config-file/), you
-can do a smaller, faster update of your Base Preview using Refresh. Refreshing a
-Base Preview:
+If you don't need to pull a new Docker image or make changes to the `init` phase in your
+[config file](/setting-up-tugboat/create-a-tugboat-config-file/), you can do a smaller, faster update of your Base
+Preview using Refresh. Refreshing a Base Preview:
 
 1. Pulls the latest code from git.
 2. Runs commands from the `update` section of the config.yml.
@@ -87,42 +79,34 @@ Base Preview:
 Want to know more about build phases? Check out:
 [the build process: explained](../../preview-deep-dive/how-previews-work/#the-build-process-explained).
 
-{{% notice tip %}} If you want to pull a fresh Docker image, or if you've made
-changes to the config.yml's `init` phase, you'll need to
-[rebuild the Base Preview](#change-a-base-preview) in order to see those
-changes. {{% /notice %}}
+{{% notice tip %}} If you want to pull a fresh Docker image, or if you've made changes to the config.yml's `init` phase,
+you'll need to [rebuild the Base Preview](#change-a-base-preview) in order to see those changes. {{% /notice %}}
 
 Tugboat provides a couple of ways to Refresh a Base Preview:
 
 - [Manually Refresh a Base Preview](#manually-refresh-a-base-preview)
 - [Automatically Refresh Base Previews](#automatically-refresh-a-base-preview)
 
-{{% notice note %}} If you've checked the
-[Repository Setting](/setting-up-tugboat/select-repo-settings/) to **Rebuild
-Stale Previews Automatically**, a successful Refresh of a Base Preview will kick
-off Rebuilds of any child Previews that were built from your Base Preview.
-{{% /notice %}}
+{{% notice note %}} If you've checked the [Repository Setting](/setting-up-tugboat/select-repo-settings/) to **Rebuild
+Stale Previews Automatically**, a successful Refresh of a Base Preview will kick off Rebuilds of any child Previews that
+were built from your Base Preview. {{% /notice %}}
 
 ### Manually Refresh a Base Preview
 
 To manually kick off a Base Preview update:
 
-1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-   upper-right of the Tugboat screen.
+1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 2. Select the project where you want to update the Base Preview.
 3. Click the name of the repo that contains Base Preview you want to update.
-4. Click the {{% ui-text %}}Actions{{% /ui-text %}} drop-down menu for the Base
-   Preview, and select {{% ui-text %}}Refresh{{% /ui-text %}} .
-5. If you want to
-   [Rebuild Previews that were built from this Base Preview](../building-new-previews/)
-   after the update, click the checkbox next to {{% ui-text %}}Rebuild Previews
-   built from this one when finished{{% /ui-text %}} .
+4. Click the {{% ui-text %}}Actions{{% /ui-text %}} drop-down menu for the Base Preview, and select
+   {{% ui-text %}}Refresh{{% /ui-text %}} .
+5. If you want to [Rebuild Previews that were built from this Base Preview](../building-new-previews/) after the update,
+   click the checkbox next to {{% ui-text %}}Rebuild Previews built from this one when finished{{% /ui-text %}} .
 6. Press the {{% ui-text %}}Refresh{{% /ui-text %}} button.
 
 {{%expand "Visual Walkthrough" %}}
 
-Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-upper-right of the Tugboat screen.
+Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 
 ![Go to username -> My Projects](/_images/go-to-user-my-projects.png)
 
@@ -134,15 +118,13 @@ Click the name of the repo that contains Base Preview you want to update.
 
 ![Click into Tugboat repository](/_images/click-into-tugboat-repository.png)
 
-Click the {{% ui-text %}}Actions{{% /ui-text %}} drop-down menu for the Base
-Preview, and select {{% ui-text %}}Refresh{{% /ui-text %}} .
+Click the {{% ui-text %}}Actions{{% /ui-text %}} drop-down menu for the Base Preview, and select
+{{% ui-text %}}Refresh{{% /ui-text %}} .
 
 ![Click the Actions drop-down, and select Refresh.](/_images/base-preview-actions-refresh.png)
 
-If you want to
-[Rebuild Previews that were built from this Base Preview](../building-new-previews/)
-after the update, click the checkbox next to {{% ui-text %}}Rebuild Previews
-built from this one when finished{{% /ui-text %}} .
+If you want to [Rebuild Previews that were built from this Base Preview](../building-new-previews/) after the update,
+click the checkbox next to {{% ui-text %}}Rebuild Previews built from this one when finished{{% /ui-text %}} .
 
 ![Confirm Rebuild Previews built from this Base Preview after Refresh](/_images/base-preview-rebuild-previews-from-base-after-refresh.png)
 
@@ -154,35 +136,27 @@ Press the {{% ui-text %}}Refresh{{% /ui-text %}} button.
 
 ### Automatically Refresh a Base Preview
 
-You'll generally want to keep your Base Preview up to date with your latest
-codebase, and a fresh copy of your database, image files, and other assets. By
-default, Tugboat automatically checks for updates every night at 12 am UTC, and
-refreshes your Base Preview with these updates. You can toggle this feature, or
-change the time and interval at which Tugboat does an automated Refresh of your
-Base Previews.
+You'll generally want to keep your Base Preview up to date with your latest codebase, and a fresh copy of your database,
+image files, and other assets. By default, Tugboat automatically checks for updates every night at 12 am UTC, and
+refreshes your Base Preview with these updates. You can toggle this feature, or change the time and interval at which
+Tugboat does an automated Refresh of your Base Previews.
 
 #### To change Tugboat's settings to automatically Refresh Base Previews:
 
-1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-   upper-right of the Tugboat screen.
-2. Select the project where you want to configure auto-update settings for Base
-   Previews.
+1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
+2. Select the project where you want to configure auto-update settings for Base Previews.
 3. Click into {{% ui-text %}}Settings{{% /ui-text %}} for the repository.
-4. Go to {{% ui-text %}}Refresh Base Previews Automatically{{% /ui-text %}} .
-   Toggle the checkbox and/or adjust the frequency and timing of these automatic
-   updates.
-5. Press the {{% ui-text %}}Save Configuration{{% /ui-text %}} button to save
-   your changes.
+4. Go to {{% ui-text %}}Refresh Base Previews Automatically{{% /ui-text %}} . Toggle the checkbox and/or adjust the
+   frequency and timing of these automatic updates.
+5. Press the {{% ui-text %}}Save Configuration{{% /ui-text %}} button to save your changes.
 
 {{%expand "Visual Walkthrough" %}}
 
-Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-upper-right of the Tugboat screen.
+Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 
 ![Go to username -> My Projects](/_images/go-to-user-my-projects.png)
 
-Select the project where you want to configure auto-update settings for Base
-Previews.
+Select the project where you want to configure auto-update settings for Base Previews.
 
 ![Select the project](/_images/select-a-project.png)
 
@@ -190,14 +164,12 @@ Click into {{% ui-text %}}Settings{{% /ui-text %}} for the repository.
 
 ![Go to Repository Settings](/_images/go-to-repository-settings.png)
 
-Go to {{% ui-text %}}Refresh Base Previews Automatically{{% /ui-text %}} .
-Toggle the checkbox and/or adjust the frequency and timing of these automatic
-updates.
+Go to {{% ui-text %}}Refresh Base Previews Automatically{{% /ui-text %}} . Toggle the checkbox and/or adjust the
+frequency and timing of these automatic updates.
 
 ![Toggle or adjust frequency/time for Refresh Base Previews Automatically setting](/_images/repository-settings-refresh-base-previews-automatically.png)
 
-Press the {{% ui-text %}}Save Configuration{{% /ui-text %}} button to save your
-changes.
+Press the {{% ui-text %}}Save Configuration{{% /ui-text %}} button to save your changes.
 
 ![Repository Settings -> Press Save Configuration button](/_images/repository-settings-press-save-configuration.png)
 

--- a/content/building-a-preview/work-with-base-previews/delete-base-preview.md
+++ b/content/building-a-preview/work-with-base-previews/delete-base-preview.md
@@ -4,38 +4,30 @@ date: 2019-09-24T11:53:17-04:00
 weight: 7
 ---
 
-Want to delete a Base Preview you're not using anymore? Keep in mind that if you
-delete a Base Preview that was used to generate child Previews, those child
-Previews will grow to their full size, which could put your project over the
-[limit of disk space](/tugboat-billing/tugboat-pricing/#how-does-tugboat-pricing-work)
-available to the project. If you don't want this, you can
-[stop using a Base Preview](../stop-using-base-preview/) to stop building new
-child Previews from this Preview, but preserve the current size of existing
-child Previews.
+Want to delete a Base Preview you're not using anymore? Keep in mind that if you delete a Base Preview that was used to
+generate child Previews, those child Previews will grow to their full size, which could put your project over the
+[limit of disk space](/tugboat-billing/tugboat-pricing/#how-does-tugboat-pricing-work) available to the project. If you
+don't want this, you can [stop using a Base Preview](../stop-using-base-preview/) to stop building new child Previews
+from this Preview, but preserve the current size of existing child Previews.
 
-{{% notice note %}} When you exceed the disk space limit in your project, you
-won't be able to build new Previews until you are under the project's disk space
-limit again. You can get under the project's space limit by
+{{% notice note %}} When you exceed the disk space limit in your project, you won't be able to build new Previews until
+you are under the project's disk space limit again. You can get under the project's space limit by
 [deleting Previews](../../administer-previews/delete-previews/), or
-[increasing your project's billing tier](/tugboat-billing/tugboat-pricing/#change-your-tugboat-plan).
-{{% /notice %}}
+[increasing your project's billing tier](/tugboat-billing/tugboat-pricing/#change-your-tugboat-plan). {{% /notice %}}
 
 ## To delete a Base Preview:
 
-1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-   upper-right of the Tugboat screen.
+1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 2. Select the project where you want to delete a Base Preview.
 3. Click into the repo where you want to delete a Base Preview.
-4. Click the {{% ui-text %}}Actions{{% /ui-text %}} drop-down menu for the Base
-   Preview you want to delete, and select {{% ui-text %}}Delete{{% /ui-text %}}.
-5. Click the checkbox next to {{% ui-text %}}Yes, delete this
-   preview{{% /ui-text %}} and then press the
+4. Click the {{% ui-text %}}Actions{{% /ui-text %}} drop-down menu for the Base Preview you want to delete, and select
+   {{% ui-text %}}Delete{{% /ui-text %}}.
+5. Click the checkbox next to {{% ui-text %}}Yes, delete this preview{{% /ui-text %}} and then press the
    {{% ui-text %}}Delete{{% /ui-text %}} button to confirm.
 
 {{%expand "Visual Walkthrough" %}}
 
-Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-upper-right of the Tugboat screen.
+Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 
 ![Go to username -> My Projects](/_images/go-to-user-my-projects.png)
 
@@ -47,14 +39,13 @@ Click into the repo where you want to delete a Base Preview.
 
 ![Click into Tugboat repository](/_images/click-into-tugboat-repository.png)
 
-Click the {{% ui-text %}}Actions{{% /ui-text %}} drop-down menu for the Base
-Preview you want to delete, and select {{% ui-text %}}Delete{{% /ui-text %}}.
+Click the {{% ui-text %}}Actions{{% /ui-text %}} drop-down menu for the Base Preview you want to delete, and select
+{{% ui-text %}}Delete{{% /ui-text %}}.
 
 ![Click the Actions drop-down, and select Delete.](/_images/base-preview-actions-delete.png)
 
-Click the checkbox next to {{% ui-text %}}Yes, delete this
-preview{{% /ui-text %}} and then press the {{% ui-text %}}Delete{{% /ui-text %}}
-button to confirm.
+Click the checkbox next to {{% ui-text %}}Yes, delete this preview{{% /ui-text %}} and then press the
+{{% ui-text %}}Delete{{% /ui-text %}} button to confirm.
 
 ![Confirm Preview delete and press Delete button](/_images/base-preview-press-delete-button.png)
 

--- a/content/building-a-preview/work-with-base-previews/set-a-base-preview.md
+++ b/content/building-a-preview/work-with-base-previews/set-a-base-preview.md
@@ -4,34 +4,27 @@ date: 2019-09-24T11:51:23-04:00
 weight: 1
 ---
 
-Whether you want to set one Base Preview, or
-[set multiple Base Previews](#add-multiple-base-previews), the process is the
-same:
+Whether you want to set one Base Preview, or [set multiple Base Previews](#add-multiple-base-previews), the process is
+the same:
 
 ## How to set a Base Preview
 
-To create a Base Preview, you'll first need to have a
-[Preview build](../../administer-previews/build-previews/) to serve as your
-starting point.
+To create a Base Preview, you'll first need to have a [Preview build](../../administer-previews/build-previews/) to
+serve as your starting point.
 
-1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-   upper-right of the Tugboat screen.
+1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 2. Select the project where you want to set a Base Preview.
-3. Click the name of the repo that contains Preview you want to use as a Base
-   Preview.
-4. Go to the {{% ui-text %}}Manage Base Previews{{% /ui-text %}} link on the
-   Repository Dashboard.
+3. Click the name of the repo that contains Preview you want to use as a Base Preview.
+4. Go to the {{% ui-text %}}Manage Base Previews{{% /ui-text %}} link on the Repository Dashboard.
 5. Click the checkbox next to the Preview you want to use as a Base Preview.
 6. Press the {{% ui-text %}}OK{{% /ui-text %}} button.
 
-That preview will be moved to the {{% ui-text %}}Base Preview{{% /ui-text %}}
-section of the Repository Dashboard. From now on, Previews will build from the
-snapshot created when the Base Preview was built.
+That preview will be moved to the {{% ui-text %}}Base Preview{{% /ui-text %}} section of the Repository Dashboard. From
+now on, Previews will build from the snapshot created when the Base Preview was built.
 
 {{%expand "Visual Walkthrough" %}}
 
-Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-upper-right of the Tugboat screen.
+Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 
 ![Go to username -> My Projects](/_images/go-to-user-my-projects.png)
 
@@ -39,13 +32,11 @@ Select the project where you want to set a Base Preview.
 
 ![Select the project](/_images/select-a-project.png)
 
-Click the name of the repo that contains Preview you want to use as a Base
-Preview.
+Click the name of the repo that contains Preview you want to use as a Base Preview.
 
 ![Click into Tugboat repository](/_images/click-into-tugboat-repository.png)
 
-Go to the {{% ui-text %}}Manage Base Previews{{% /ui-text %}} link on the
-Repository Dashboard.
+Go to the {{% ui-text %}}Manage Base Previews{{% /ui-text %}} link on the Repository Dashboard.
 
 ![Go to Manage Base Previews](/_images/set-base-preview-go-to-manage-base-previews.png)
 
@@ -57,14 +48,12 @@ Press the {{% ui-text %}}OK{{% /ui-text %}} button.
 
 ![Press OK to confirm Base Preview](/_images/set-base-preview-press-ok.png)
 
-That preview will be moved to the {{% ui-text %}}Base Preview{{% /ui-text %}}
-section of the Repository Dashboard.
+That preview will be moved to the {{% ui-text %}}Base Preview{{% /ui-text %}} section of the Repository Dashboard.
 
 ![Base Preview in repository](/_images/set-base-preview-after.png)
 
-If you're ever wondering which Base Preview was used when generating a Preview,
-check under the name of the Preview; you're looking for the "from _Base Preview
-Name_":
+If you're ever wondering which Base Preview was used when generating a Preview, check under the name of the Preview;
+you're looking for the "from _Base Preview Name_":
 
 ![View Base Preview for Preview](/_images/view-base-preview-for-preview.png)
 
@@ -72,16 +61,13 @@ Name_":
 
 ## Add multiple Base Previews
 
-To set more than one Base Preview, follow the directions above, but check the
-checkboxes next to all of the Previews that you'd like to set as Base Previews
-when you get to Step 5.
+To set more than one Base Preview, follow the directions above, but check the checkboxes next to all of the Previews
+that you'd like to set as Base Previews when you get to Step 5.
 
 ![Set multiple Base Previews](/_images/set-multiple-base-previews.png)
 
-When you've selected multiple Base Previews, every new Preview build (including
-automated builds from pull requests) will create a build from _each_ Base
-Preview. In my sample project, I've set two base Previews, and building a
-Preview from a new PR automatically created two Previews - one for each Base
-Preview.
+When you've selected multiple Base Previews, every new Preview build (including automated builds from pull requests)
+will create a build from _each_ Base Preview. In my sample project, I've set two base Previews, and building a Preview
+from a new PR automatically created two Previews - one for each Base Preview.
 
 ![Multiple Base Previews generating multiple Preview builds](/_images/multiple-base-preview-builds.png)

--- a/content/building-a-preview/work-with-base-previews/stop-using-base-preview.md
+++ b/content/building-a-preview/work-with-base-previews/stop-using-base-preview.md
@@ -4,32 +4,26 @@ date: 2019-09-24T11:52:51-04:00
 weight: 5
 ---
 
-When you no longer want new Preview Builds to use a Base Preview; for example,
-if you've moved to a new concept, want to switch to a development branch or
-otherwise want to stop using a Base Preview; you can remove that Base Preview.
-This keeps the Base Preview and child Previews in your Tugboat project, but new
-builds will no longer start with this Base Preview. If you want to delete a Base
-Preview, instead, see: [Delete a Base Preview](../delete-base-preview/).
+When you no longer want new Preview Builds to use a Base Preview; for example, if you've moved to a new concept, want to
+switch to a development branch or otherwise want to stop using a Base Preview; you can remove that Base Preview. This
+keeps the Base Preview and child Previews in your Tugboat project, but new builds will no longer start with this Base
+Preview. If you want to delete a Base Preview, instead, see: [Delete a Base Preview](../delete-base-preview/).
 
 ## To stop using a Base Preview:
 
-1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-   upper-right of the Tugboat screen.
+1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 2. Select the project where you want to stop using a Base Preview.
 3. Click into the repo where you want to stop using a Base Preview.
-4. Go to the {{% ui-text %}}Manage Base Previews{{% /ui-text %}} link on the
-   Repository Dashboard.
+4. Go to the {{% ui-text %}}Manage Base Previews{{% /ui-text %}} link on the Repository Dashboard.
 5. Click the checkbox next to the Base Preview you want to stop using.
 6. Press the {{% ui-text %}}OK{{% /ui-text %}} button.
 
-The deselected Preview will disappear from the Base Preview section of the
-dashboard, and subsequent Preview builds - including automated builds from git
-provider integrations - will no longer start from that Base Preview.
+The deselected Preview will disappear from the Base Preview section of the dashboard, and subsequent Preview builds -
+including automated builds from git provider integrations - will no longer start from that Base Preview.
 
 {{%expand "Visual Walkthrough" %}}
 
-Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-upper-right of the Tugboat screen.
+Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 
 ![Go to username -> My Projects](/_images/go-to-user-my-projects.png)
 
@@ -41,8 +35,7 @@ Click into the repo where you want to stop using a Base Preview.
 
 ![Click into Tugboat repository](/_images/click-into-tugboat-repository.png)
 
-Go to the {{% ui-text %}}Manage Base Previews{{% /ui-text %}} link on the
-Repository Dashboard.
+Go to the {{% ui-text %}}Manage Base Previews{{% /ui-text %}} link on the Repository Dashboard.
 
 ![Go to Manage Base Previews](/_images/stop-using-base-preview-manage-base-previews.png)
 

--- a/content/faq/common-questions.md
+++ b/content/faq/common-questions.md
@@ -6,24 +6,23 @@ weight: 2
 
 ## Do you provide production-level hosting?
 
-No. Tugboat previews are intended to be short-lived, and do not come with the
-stability or support guarantees needed to host a production application.
+No. Tugboat previews are intended to be short-lived, and do not come with the stability or support guarantees needed to
+host a production application.
 
 ## Can I have SSH access to a Preview?
 
-No. Direct SSH access to a Preview is not possible. However, shell access is
-provided in both the web interface and the [command line tool](/tugboat-cli/).
+No. Direct SSH access to a Preview is not possible. However, shell access is provided in both the web interface and the
+[command line tool](/tugboat-cli/).
 
 ## How does Tugboat deal with sending email?
 
-Tugboat makes a best effort to capture outbound email. Using the local
-`sendmail` or the SMTP server at `$TUGBOAT_SMTP` will result in email being
-captured by Tugboat. These captured emails are only saved for as long as the
-Preview that sent them exists.
+Tugboat makes a best effort to capture outbound email. Using the local `sendmail` or the SMTP server at `$TUGBOAT_SMTP`
+will result in email being captured by Tugboat. These captured emails are only saved for as long as the Preview that
+sent them exists.
 
-Tugboat does not attempt to capture any other outbound SMTP server connections,
-so if you are concerned with sending emails to customers from a QA environment,
-be sure to update your application configuration to use Tugboat's SMTP server.
+Tugboat does not attempt to capture any other outbound SMTP server connections, so if you are concerned with sending
+emails to customers from a QA environment, be sure to update your application configuration to use Tugboat's SMTP
+server.
 
 For more details, see:
 [Inside a Preview -> Captured Mail](/building-a-preview/preview-deep-dive/inside-a-preview/#captured-mail).

--- a/content/faq/compatible-technologies.md
+++ b/content/faq/compatible-technologies.md
@@ -7,15 +7,13 @@ weight: 1
 ## Does Tugboat work with...?
 
 Tugboat supports pretty much anything that runs on Linux. Look through our
-[prebuilt service images](/reference/tugboat-images/) to see what we currently
-have available. If something that you need is missing, let us know, and we will
-work with you to get it added to the list.
+[prebuilt service images](/reference/tugboat-images/) to see what we currently have available. If something that you
+need is missing, let us know, and we will work with you to get it added to the list.
 
 People frequently ask about whether Tugboat works with these technologies:
 
 - **Acquia Cloud?** Yes!
-- **Pantheon?** Yes! We even have a
-  [tutorial](/starter-configs/tutorials/pantheon/) to show you how.
+- **Pantheon?** Yes! We even have a [tutorial](/starter-configs/tutorials/pantheon/) to show you how.
 - **GitHub, GitLab, BitBucket?** Yes! Check out:
   [Setting up Tugboat -> Connect with your git provider](/setting-up-tugboat/connect-with-your-provider/)
 - **Self-hosted git repositories?** Yes! See:
@@ -23,13 +21,12 @@ People frequently ask about whether Tugboat works with these technologies:
 - **My own images?** Yes! See:
   [Setting up Services -> Specify a Service image](/setting-up-services/how-to-set-up-services/specify-a-service-image/)
 - **My existing database?** Yes! Take a look at
-  [Starter Configs -> Import a MySQL Database](/starter-configs/code-snippets/import-mysql-database/)
-  for an example.
+  [Starter Configs -> Import a MySQL Database](/starter-configs/code-snippets/import-mysql-database/) for an example.
 
 ## Does Tugboat have a Slack integration?
 
-Tugboat does not currently have a direct Slack integration. However, you can get
-very similar functionality if you're using a git integration with Slack:
+Tugboat does not currently have a direct Slack integration. However, you can get very similar functionality if you're
+using a git integration with Slack:
 
 - [GitHub for Slack](https://github.com/integrations/slack)
 - [GitLab Slack Application](https://docs.gitlab.com/ee/user/project/integrations/gitlab_slack_application.html)
@@ -43,5 +40,5 @@ to share details about your Tugboat Previews, such as:
 - Set Pull Request Deployment Status
 - Post Preview Links in Pull Request Comments
 
-When using these settings, Tugboat's updates to your git repository can be
-carried through your git Slack integration into your relevant Slack channels.
+When using these settings, Tugboat's updates to your git repository can be carried through your git Slack integration
+into your relevant Slack channels.

--- a/content/faq/find-tugboat-ids.md
+++ b/content/faq/find-tugboat-ids.md
@@ -6,8 +6,7 @@ weight: 4
 
 ## How to find Tugboat IDs
 
-Whether you're reaching out to support or working in the Tugboat CLI, sometimes
-you'll need to know a Tugboat ID.
+Whether you're reaching out to support or working in the Tugboat CLI, sometimes you'll need to know a Tugboat ID.
 
 - [Find Tugboat IDs in the web interface](#in-the-tugboat-web-interface)
 - [Find Tugboat IDs in the CLI](#in-the-tugboat-cli)
@@ -21,16 +20,14 @@ you'll need to know a Tugboat ID.
 
 #### Project ID in the web interface
 
-1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-   upper-right of the Tugboat screen.
+1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 2. Select the project whose ID you want to know.
-3. Look in the address bar for the project ID; it's everything following
-   tugboat.qa/ - i.e. tugboat.qa/**5e3c40e79366b1c43a153f38**.
+3. Look in the address bar for the project ID; it's everything following tugboat.qa/ - i.e.
+   tugboat.qa/**5e3c40e79366b1c43a153f38**.
 
 {{%expand "Visual Walkthrough" %}}
 
-Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-upper-right of the Tugboat screen.
+Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 
 ![Go to username -> My Projects](/_images/go-to-user-my-projects.png)
 
@@ -38,8 +35,8 @@ Select the project whose ID you want to know.
 
 ![Select the project](/_images/select-a-project.png)
 
-Look in the address bar for the project ID; it's everything following
-tugboat.qa/ - i.e. tugboat.qa/**5e3c40e79366b1c43a153f38**.
+Look in the address bar for the project ID; it's everything following tugboat.qa/ - i.e.
+tugboat.qa/**5e3c40e79366b1c43a153f38**.
 
 ![Project ID in address bar](/_images/tugboat-project-id.png)
 
@@ -47,17 +44,15 @@ tugboat.qa/ - i.e. tugboat.qa/**5e3c40e79366b1c43a153f38**.
 
 #### Repository ID in the web interface
 
-1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-   upper-right of the Tugboat screen.
+1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 2. Select the project that contains the repository whose ID you want to know.
 3. Click into the repository whose ID you want to know.
-4. Look in the address bar for the repository ID; it's everything following
-   tugboat.qa/ - i.e. tugboat.qa/**5e3c414e9366b1d9e1154334**.
+4. Look in the address bar for the repository ID; it's everything following tugboat.qa/ - i.e.
+   tugboat.qa/**5e3c414e9366b1d9e1154334**.
 
 {{%expand "Visual Walkthrough" %}}
 
-Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-upper-right of the Tugboat screen.
+Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 
 ![Go to username -> My Projects](/_images/go-to-user-my-projects.png)
 
@@ -69,8 +64,8 @@ Click into the repository whose ID you want to know.
 
 ![Click into Tugboat repository](/_images/click-into-tugboat-repository.png)
 
-Look in the address bar for the repository ID; it's everything following
-tugboat.qa/ - i.e. tugboat.qa/**5e3c414e9366b1d9e1154334**.
+Look in the address bar for the repository ID; it's everything following tugboat.qa/ - i.e.
+tugboat.qa/**5e3c414e9366b1d9e1154334**.
 
 ![Repository ID in address bar](/_images/repository-id-in-address-bar.png)
 
@@ -78,19 +73,15 @@ tugboat.qa/ - i.e. tugboat.qa/**5e3c414e9366b1d9e1154334**.
 
 #### Preview ID in the web interface
 
-1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-   upper-right of the Tugboat screen.
+1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 2. Select the project that contains the Preview whose ID you want to know.
-3. Click the name of the repo that contains the Preview whose ID you want to
-   know.
-4. Click into the Preview's name, and look in the address bar for the Preview
-   ID; it's everything following tugboat.qa/ - i.e.
-   tugboat.qa/**5e3c415d9366b17547154387**.
+3. Click the name of the repo that contains the Preview whose ID you want to know.
+4. Click into the Preview's name, and look in the address bar for the Preview ID; it's everything following
+   tugboat.qa/ - i.e. tugboat.qa/**5e3c415d9366b17547154387**.
 
 {{%expand "Visual Walkthrough" %}}
 
-Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-upper-right of the Tugboat screen.
+Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 
 ![Go to username -> My Projects](/_images/go-to-user-my-projects.png)
 
@@ -106,8 +97,8 @@ Click into the Preview's name.
 
 ![Click into Preview name](/_images/click-into-preview-name.png)
 
-Look in the address bar for the Preview ID; it's everything following
-tugboat.qa/ - i.e. tugboat.qa/**5e3c415d9366b17547154387**.
+Look in the address bar for the Preview ID; it's everything following tugboat.qa/ - i.e.
+tugboat.qa/**5e3c415d9366b17547154387**.
 
 ![Preview ID in the address bar](/_images/preview-id-in-address-bar.png)
 
@@ -115,22 +106,16 @@ tugboat.qa/ - i.e. tugboat.qa/**5e3c415d9366b17547154387**.
 
 #### Service ID in the web interface
 
-1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-   upper-right of the Tugboat screen.
-2. Select the project that contains the Preview whose service ID you want to
-   know.
-3. Click the name of the repo that contains the Preview whose service ID you
-   want to know.
-4. Click into the name of the Preview that contains the service whose ID you
-   want to know.
-5. Click into the service and look in the address bar for the service ID; it's
-   everything following tugboat.qa/ - i.e.
+1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
+2. Select the project that contains the Preview whose service ID you want to know.
+3. Click the name of the repo that contains the Preview whose service ID you want to know.
+4. Click into the name of the Preview that contains the service whose ID you want to know.
+5. Click into the service and look in the address bar for the service ID; it's everything following tugboat.qa/ - i.e.
    tugboat.qa/**5e3c415e7b9f1ce8aa1c0856**.
 
 {{%expand "Visual Walkthrough" %}}
 
-Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-upper-right of the Tugboat screen.
+Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 
 ![Go to username -> My Projects](/_images/go-to-user-my-projects.png)
 
@@ -138,13 +123,11 @@ Select the project that contains the Preview whose service ID you want to know.
 
 ![Select the project](/_images/select-a-project.png)
 
-Click the name of the repo that contains the Preview whose service ID you want
-to know.
+Click the name of the repo that contains the Preview whose service ID you want to know.
 
 ![Click into Tugboat repository](/_images/click-into-tugboat-repository.png)
 
-Click into the name of the Preview that contains the service whose ID you want
-to know.
+Click into the name of the Preview that contains the service whose ID you want to know.
 
 ![Click into Preview name](/_images/click-into-preview-name.png)
 
@@ -152,8 +135,8 @@ Click into the service whose ID you want to know.
 
 ![Click into the service](/_images/click-into-service-name.png)
 
-Look in the address bar for the service ID; it's everything following
-tugboat.qa/ - i.e. tugboat.qa/**5e3c415e7b9f1ce8aa1c0856**.
+Look in the address bar for the service ID; it's everything following tugboat.qa/ - i.e.
+tugboat.qa/**5e3c415e7b9f1ce8aa1c0856**.
 
 ![Service ID in the address bar](/_images/service-id-in-address-bar.png)
 
@@ -161,8 +144,8 @@ tugboat.qa/ - i.e. tugboat.qa/**5e3c415e7b9f1ce8aa1c0856**.
 
 ### In the Tugboat CLI:
 
-With the [Tugboat CLI installed](/tugboat-cli/install-the-cli/), you can find
-IDs using a combination of commands and args.
+With the [Tugboat CLI installed](/tugboat-cli/install-the-cli/), you can find IDs using a combination of commands and
+args.
 
 - [Project ID](#project-id-in-the-cli)
 - [Repository ID](#repository-id-in-the-cli)
@@ -225,8 +208,7 @@ You'll see a response similar to this:
 
 ##### List the repositories in a project
 
-To list only the repository IDs for a specific project with the ID of
-`5dfic23e53my123401b8d0e5`:
+To list only the repository IDs for a specific project with the ID of `5dfic23e53my123401b8d0e5`:
 
 ```sh
 tugboat ls repos project=5dfic23e53my123401b8d0e5
@@ -281,8 +263,7 @@ You'll see a response similar to this:
 
 ##### List the Previews in a specific project
 
-To list only the Previews in a specific project with the ID of
-`5dfic23e53my123401b8d0e5`:
+To list only the Previews in a specific project with the ID of `5dfic23e53my123401b8d0e5`:
 
 ```sh
 tugboat ls previews project=5dfic23e53my123401b8d0e5
@@ -309,8 +290,7 @@ You'll see a response similar to this:
 
 ##### List the Previews in a specific repository
 
-To list only the Previews in a specific repository with the ID of
-`5dfic23e53my123401b8d0e7`:
+To list only the Previews in a specific repository with the ID of `5dfic23e53my123401b8d0e7`:
 
 ```sh
 tugboat ls previews repo=5dfic23e53my123401b8d0e7
@@ -333,8 +313,7 @@ You'll see a response similar to this:
 
 #### Service ID in the CLI
 
-To list the services in a specific Preview with the ID of
-`5dfic54972db400001b8d290`:
+To list the services in a specific Preview with the ID of `5dfic54972db400001b8d290`:
 
 ```sh
 tugboat ls services preview=5dfic54972db400001b8d290

--- a/content/faq/tugboat-ip-addresses.md
+++ b/content/faq/tugboat-ip-addresses.md
@@ -4,10 +4,8 @@ date: 2019-09-26T15:27:00-04:00
 weight: 3
 ---
 
-Do you need to whitelist Tugboat's IP addresses so you can access something
-behind a firewall? We've got you covered! Our IPs sometimes change due to
-maintenance, so here's how you can use `dig` to perform a DNS lookup and check
-our IPs:
+Do you need to whitelist Tugboat's IP addresses so you can access something behind a firewall? We've got you covered!
+Our IPs sometimes change due to maintenance, so here's how you can use `dig` to perform a DNS lookup and check our IPs:
 
 ```sh
 $ dig txt _egress.tugboat.qa

--- a/content/reference/environment-variables.md
+++ b/content/reference/environment-variables.md
@@ -18,137 +18,110 @@ weight: 5
 
 ## Tugboat Environment Variables
 
-Tugboat injects the following environment variables into every Service. These
-variables are available for the entire lifetime of a Service. This includes both
-build-time as well as run-time. So, they can be used in Build Scripts as well as
-run-time configuration files, etc.
+Tugboat injects the following environment variables into every Service. These variables are available for the entire
+lifetime of a Service. This includes both build-time as well as run-time. So, they can be used in Build Scripts as well
+as run-time configuration files, etc.
 
-- **`$TUGBOAT_DEFAULT_SERVICE`** - The friendly name of the default Service of
-  the current Preview.
+- **`$TUGBOAT_DEFAULT_SERVICE`** - The friendly name of the default Service of the current Preview.
 
-- **`$TUGBOAT_DEFAULT_SERVICE_ID`** - The ID of the default Service of the
-  current Preview.
+- **`$TUGBOAT_DEFAULT_SERVICE_ID`** - The ID of the default Service of the current Preview.
 
-- **`$TUGBOAT_DEFAULT_SERVICE_TOKEN`** - The authentication token for the
-  default Service of the current Preview.
+- **`$TUGBOAT_DEFAULT_SERVICE_TOKEN`** - The authentication token for the default Service of the current Preview.
 
-- **`$TUGBOAT_DEFAULT_SERVICE_URL`** - The full URL for the default Service of
-  the current Preview. This is also the default URL for the Preview itself.
+- **`$TUGBOAT_DEFAULT_SERVICE_URL`** - The full URL for the default Service of the current Preview. This is also the
+  default URL for the Preview itself.
 
-- **`$TUGBOAT_DEFAULT_SERVICE_URL_HOST`** - The "host" part of the URL for the
-  default Service of the current Preview.
+- **`$TUGBOAT_DEFAULT_SERVICE_URL_HOST`** - The "host" part of the URL for the default Service of the current Preview.
 
-- **`$TUGBOAT_DEFAULT_SERVICE_URL_PROTOCOL`** - The "protocol" part of the URL
-  for the default Service of the current Preview.
+- **`$TUGBOAT_DEFAULT_SERVICE_URL_PROTOCOL`** - The "protocol" part of the URL for the default Service of the current
+  Preview.
 
-- **`$TUGBOAT_DEFAULT_SERVICE_URL_PATH`** - The "path" part of the URL for the
-  default Service of the current Preview.
+- **`$TUGBOAT_DEFAULT_SERVICE_URL_PATH`** - The "path" part of the URL for the default Service of the current Preview.
 
-- **`$TUGBOAT_DEFAULT_SERVICE_CONFIG_ALIASES`** - A comma-separated list of
-  aliases configured for the default Service of the current Preview.
+- **`$TUGBOAT_DEFAULT_SERVICE_CONFIG_ALIASES`** - A comma-separated list of aliases configured for the default Service
+  of the current Preview.
 
-- **`$TUGBOAT_DEFAULT_SERVICE_CONFIG_DOMAIN`** - The configured domain for the
-  default Service of the current Preview.
+- **`$TUGBOAT_DEFAULT_SERVICE_CONFIG_DOMAIN`** - The configured domain for the default Service of the current Preview.
 
 - **`$TUGBOAT_PREVIEW_ID`** - The ID of the current Preview.
 
 - **`$TUGBOAT_PREVIEW`** - The friendly name of the current Preview.
 
-- **`$TUGBOAT_PREVIEW_TYPE`** - What type of preview this is. The value will be
-  one of: `branch`, `tag`, `commit`, `pullrequest`, or `mergerequest`.
+- **`$TUGBOAT_PREVIEW_TYPE`** - What type of preview this is. The value will be one of: `branch`, `tag`, `commit`,
+  `pullrequest`, or `mergerequest`.
 
 - **`$TUGBOAT_PREVIEW_SHA`** - The git SHA that the preview was built from.
 
-- **`$TUGBOAT_PROJECT_ID`** - The ID of the project that the current Preview
-  belongs to.
+- **`$TUGBOAT_PROJECT_ID`** - The ID of the project that the current Preview belongs to.
 
-- **`$TUGBOAT_PROJECT`** - The friendly name of the project that the current
-  Preview belongs to.
+- **`$TUGBOAT_PROJECT`** - The friendly name of the project that the current Preview belongs to.
 
-- **`$TUGBOAT_REPO_ID`** - The ID of the repo that the current Preview belongs
-  to.
+- **`$TUGBOAT_REPO_ID`** - The ID of the repo that the current Preview belongs to.
 
-- **`$TUGBOAT_REPO`** - The friendly name of the repo that the current Preview
-  belongs to.
+- **`$TUGBOAT_REPO`** - The friendly name of the repo that the current Preview belongs to.
 
-- **`$TUGBOAT_ROOT`** - The filesystem location where the git repository is
-  cloned.
+- **`$TUGBOAT_ROOT`** - The filesystem location where the git repository is cloned.
 
 - **`$TUGBOAT_SERVICE_ID`** - The ID of the current service.
 
-- **`$TUGBOAT_SERVICE`** - The friendly name of the current Service. This is
-  also the hostname used to reference this Service container from other
-  Services.
+- **`$TUGBOAT_SERVICE`** - The friendly name of the current Service. This is also the hostname used to reference this
+  Service container from other Services.
 
-- **`$TUGBOAT_SMTP`** - The hostname of a Tugboat SMTP server that can be used
-  to capture outbound email from the Preview.
+- **`$TUGBOAT_SMTP`** - The hostname of a Tugboat SMTP server that can be used to capture outbound email from the
+  Preview.
 
 ## Exposed Service Variables
 
-If a Service has an exposed HTTP port configured, the following variables are
-also available with information about the Service's public URL
+If a Service has an exposed HTTP port configured, the following variables are also available with information about the
+Service's public URL
 
-- **`$TUGBOAT_SERVICE_TOKEN`** - The authentication token for the Tugboat
-  Service. This is used by the Tugboat HTTP proxy to grant access to a Service
-  and is passed through mostly as an informational value. Additional
-  verification could be done in the application if necessary.
+- **`$TUGBOAT_SERVICE_TOKEN`** - The authentication token for the Tugboat Service. This is used by the Tugboat HTTP
+  proxy to grant access to a Service and is passed through mostly as an informational value. Additional verification
+  could be done in the application if necessary.
 
 - **`$TUGBOAT_SERVICE_URL`** - The full URL of the current Service.
 
-- **`$TUGBOAT_SERVICE_URL_PROTOCOL`** - The "protocol" part of the current
-  service's URL.
+- **`$TUGBOAT_SERVICE_URL_PROTOCOL`** - The "protocol" part of the current service's URL.
 
-- **`$TUGBOAT_SERVICE_URL_HOST`** - The "host" part of the current service's
-  URL.
+- **`$TUGBOAT_SERVICE_URL_HOST`** - The "host" part of the current service's URL.
 
-- **`$TUGBOAT_SERVICE_URL_PATH`** - The "path" part of the current service's
-  URL.
+- **`$TUGBOAT_SERVICE_URL_PATH`** - The "path" part of the current service's URL.
 
-- **`$TUGBOAT_SERVICE_CONFIG_ALIASES`** - A comma-separated list of aliases
-  configured for the current service.
+- **`$TUGBOAT_SERVICE_CONFIG_ALIASES`** - A comma-separated list of aliases configured for the current service.
 
-- **`$TUGBOAT_SERVICE_CONFIG_DOMAIN`** - The configured domain for the current
-  service.
+- **`$TUGBOAT_SERVICE_CONFIG_DOMAIN`** - The configured domain for the current service.
 
 ## Base Preview Environment Variables
 
-If a Preview was built from a Base Preview, the following variables are also
-available with information about the Base Preview.
+If a Preview was built from a Base Preview, the following variables are also available with information about the Base
+Preview.
 
 - **`$TUGBOAT_BASE_PREVIEW`** - The friendly name of the Base Preview.
 
 - **`$TUGBOAT_BASE_PREVIEW_ID`** - The ID of the Base Preview.
 
-- **`$TUGBOAT_BASE_PREVIEW_TOKEN`** - The authentication token of the Base
-  Preview's default Service.
+- **`$TUGBOAT_BASE_PREVIEW_TOKEN`** - The authentication token of the Base Preview's default Service.
 
-- **`$TUGBOAT_BASE_PREVIEW_URL`** - The public URL for the Base Preview's
-  default Service.
+- **`$TUGBOAT_BASE_PREVIEW_URL`** - The public URL for the Base Preview's default Service.
 
-- **`$TUGBOAT_BASE_PREVIEW_URL_PROTOCOL`** - The "protocol" part of the Base
-  Preview's default Service URL.
+- **`$TUGBOAT_BASE_PREVIEW_URL_PROTOCOL`** - The "protocol" part of the Base Preview's default Service URL.
 
-- **`$TUGBOAT_BASE_PREVIEW_URL_HOST`** - The "host" part of the Base Preview's
-  default Service URL.
+- **`$TUGBOAT_BASE_PREVIEW_URL_HOST`** - The "host" part of the Base Preview's default Service URL.
 
-- **`$TUGBOAT_BASE_PREVIEW_URL_PATH`** - The "path" part of the Base Preview's
-  default Service URL.
+- **`$TUGBOAT_BASE_PREVIEW_URL_PATH`** - The "path" part of the Base Preview's default Service URL.
 
 ## Provider-specific Environment Variables
 
 ### Bitbucket
 
-These variables are injected into Tugboat Previews that are built from a
-Bitbucket repository.
+These variables are injected into Tugboat Previews that are built from a Bitbucket repository.
 
 - **`$TUGBOAT_BITBUCKET_OWNER`** - The owner of the Bitbucket repository.
 
-- **`$TUGBOAT_BITBUCKET_SLUG`** - The URL-friendly name of the Bitbucket
-  repository. See
+- **`$TUGBOAT_BITBUCKET_SLUG`** - The URL-friendly name of the Bitbucket repository. See
   https://confluence.atlassian.com/bitbucket/what-is-a-slug-224395839.html
 
-These variables are only injected into Tugboat Previews that are built from a
-Bitbucket pull request.
+These variables are only injected into Tugboat Previews that are built from a Bitbucket pull request.
 
 - **`$TUGBOAT_BITBUCKET_PR`** - The Bitbucket pull request number.
 
@@ -156,27 +129,23 @@ Bitbucket pull request.
 
 * **`$TUGBOAT_BITBUCKET_SOURCE`** - The name of the pull request source branch.
 
-* **`$TUGBOAT_BITBUCKET_DESTINATION`** - The name of the pull request
-  destination branch.
+* **`$TUGBOAT_BITBUCKET_DESTINATION`** - The name of the pull request destination branch.
 
 ### Git
 
-These variables are injected into Tugboat Previews that are built from a raw git
-repository.
+These variables are injected into Tugboat Previews that are built from a raw git repository.
 
 - **`$TUGBOAT_GIT_REPO`** - The address of the git repository.
 
 ### GitHub
 
-These variables are injected into Tugboat Previews that are built from a GitHub
-repository.
+These variables are injected into Tugboat Previews that are built from a GitHub repository.
 
 - **`$TUGBOAT_GITHUB_OWNER`** - The owner of the GitHub repository.
 
 - **`$TUGBOAT_GITHUB_REPO`** - The name of the GitHub repository.
 
-These variables are only injected into Tugboat Previews that are built from a
-GitHub pull request.
+These variables are only injected into Tugboat Previews that are built from a GitHub pull request.
 
 - **`$TUGBOAT_GITHUB_PR`** - The GitHub pull request number.
 
@@ -188,15 +157,13 @@ GitHub pull request.
 
 ### GitLab
 
-These variables are injected into Tugboat Previews that are built from a GitLab
-repository.
+These variables are injected into Tugboat Previews that are built from a GitLab repository.
 
 - **`$TUGBOAT_GITLAB_NAMESPACE`** - The namespace of the GitLab repository.
 
 - **`$TUGBOAT_GITLAB_PROJECT`** - The project name of the GitLab repository.
 
-These variables are only injected into Tugboat Previews that are built from a
-GitLab merge request.
+These variables are only injected into Tugboat Previews that are built from a GitLab merge request.
 
 - **`$TUGBOAT_GITLAB_MR`** - The GitLab merge request number.
 
@@ -208,16 +175,14 @@ GitLab merge request.
 
 ### Stash / Bitbucket Server
 
-These variables are injected into a Tugboat Previews that are built from a Stash
-or Bitbucket Server repository.
+These variables are injected into a Tugboat Previews that are built from a Stash or Bitbucket Server repository.
 
 - **`$TUGBOAT_STASH_PROJECT`** - The project where the repository lives.
 
 - **`$TUGBOAT_STASH_SLUG`** - The URL-friendly name of the repository. See
   https://confluence.atlassian.com/bitbucket/what-is-a-slug-224395839.html
 
-These variables are only injected into Tugboat Previews that are built from a
-Stash or Bitbucket Server pull request.
+These variables are only injected into Tugboat Previews that are built from a Stash or Bitbucket Server pull request.
 
 - **`$TUGBOAT_STASH_PR`** - The pull request number.
 
@@ -225,5 +190,4 @@ Stash or Bitbucket Server pull request.
 
 * **`$TUGBOAT_STASH_SOURCE`** - The name of the pull request source branch.
 
-* **`$TUGBOAT_STASH_DESTINATION`** - The name of the pull request destination
-  branch.
+* **`$TUGBOAT_STASH_DESTINATION`** - The name of the pull request destination branch.

--- a/content/reference/tugboat-configuration.md
+++ b/content/reference/tugboat-configuration.md
@@ -23,8 +23,7 @@ The following attributes configure how Service URLs are generated
 | [alias_type](#alias-type) | String  | What kind of aliases to generate                          |
 | [subpath](#subpath)       | Boolean | Whether subpath URLs should be generated for this Service |
 
-The following attributes configure how the Tugboat proxy routes HTTP requests to
-the Service:
+The following attributes configure how the Tugboat proxy routes HTTP requests to the Service:
 
 | Key                         | Type    | Description                                               |
 | :-------------------------- | :------ | :-------------------------------------------------------- |
@@ -43,20 +42,16 @@ the Service:
 - **Default:** `default`
 - **Required:** No
 
-What type of URL aliases to generate for the Service. Valid options are
-`default` or `domain`. Alias URLs are generated in addition to the normal
-Service URLs.
+What type of URL aliases to generate for the Service. Valid options are `default` or `domain`. Alias URLs are generated
+in addition to the normal Service URLs.
 
 **`default`**
 
-When `alias_type` is set to `default`, the alias URLs are constructed by
-substituting the preview name in the Service URL with the values of `aliases`.
-The values of `aliases` are sanitized based on the value of
-[`subpath`](#subpath).
+When `alias_type` is set to `default`, the alias URLs are constructed by substituting the preview name in the Service
+URL with the values of `aliases`. The values of `aliases` are sanitized based on the value of [`subpath`](#subpath).
 
-If `subpath` is `false`, alias values are sanitized to create a valid host name,
-and is truncated to 30 characters, to make the host name a maximum of 63
-characters. If `subpath` is `true`, the alias values are URL encoded.
+If `subpath` is `false`, alias values are sanitized to create a valid host name, and is truncated to 30 characters, to
+make the host name a maximum of 63 characters. If `subpath` is `true`, the alias values are URL encoded.
 
 If `aliases` is set to `['foo', 'bar']`, alias URLs look like the following
 
@@ -70,10 +65,9 @@ or
 
 **`domain`**
 
-When `alias_type` is set to `domain`, the alias URLs are constructing by
-substituting the domain part of the Service URL with the values of `aliases`.
-The alias values are sanitized to create a valid domain name. If `aliases` is
-set to `['foo.com', 'bar.com']`, alias URLs look like the following
+When `alias_type` is set to `domain`, the alias URLs are constructing by substituting the domain part of the Service URL
+with the values of `aliases`. The alias values are sanitized to create a valid domain name. If `aliases` is set to
+`['foo.com', 'bar.com']`, alias URLs look like the following
 
 - https://pr123-4vdrhxvyddvr5tne7zcr4y72vzowqohj.foo.com
 - https://pr123-4vdrhxvyddvr5tne7zcr4y72vzowqohj.bar.com
@@ -83,9 +77,8 @@ or
 - https://foo.com/pr123-4vdrhxvyddvr5tne7zcr4y72vzowqohj/
 - https://bar.com/pr123-4vdrhxvyddvr5tne7zcr4y72vzowqohj/
 
-In order for these domains to resolve, a DNS entry must be added to the alias
-domains as a `CNAME` to `previews.tugboat.qa`. A wildcard entry is required if
-`subpath` is set to `false`.
+In order for these domains to resolve, a DNS entry must be added to the alias domains as a `CNAME` to
+`previews.tugboat.qa`. A wildcard entry is required if `subpath` is set to `false`.
 
 ---
 
@@ -95,10 +88,9 @@ domains as a `CNAME` to `previews.tugboat.qa`. A wildcard entry is required if
 - **Default:** _no default_
 - **Required:** No
 
-A list of aliases to generate URLs for. If set, additional alias URLs will be
-generated for the service. These URLs can be used to route to different
-endpoints inside of the Service, such as for a Drupal Multisite. How the alias
-URLs are constructed depend on the value of [`alias_type`](#alias-type)
+A list of aliases to generate URLs for. If set, additional alias URLs will be generated for the service. These URLs can
+be used to route to different endpoints inside of the Service, such as for a Drupal Multisite. How the alias URLs are
+constructed depend on the value of [`alias_type`](#alias-type)
 
 ---
 
@@ -108,8 +100,7 @@ URLs are constructed depend on the value of [`alias_type`](#alias-type)
 - **Default:** `false` (`true` when `default: true` is set)
 - **Required:** No
 
-Whether or not this Service should have a copy of the git repository cloned into
-it.
+Whether or not this Service should have a copy of the git repository cloned into it.
 
 ---
 
@@ -119,8 +110,8 @@ it.
 - **Default:** `/var/lib/tugboat`
 - **Required:** No
 
-Specifies the path where the git repository should be cloned if `checkout: true`
-is set. If this path already exists, the clone will fail.
+Specifies the path where the git repository should be cloned if `checkout: true` is set. If this path already exists,
+the clone will fail.
 
 ---
 
@@ -130,15 +121,11 @@ is set. If this path already exists, the clone will fail.
 - **Default:** _no default_
 - **Required:** No
 
-A set of commands to run during various points in a Preview's lifecycle. These
-commands are divided into the following stages. Each stage consists of a list of
-commands. Each command is run in its own context, so things like changing
-directories does not "stick" between commands. If that behavior is required, an
-external script should be called.
+A set of commands to run during various points in a Preview's lifecycle. These commands are divided into the following
+stages. Each stage consists of a list of commands. Each command is run in its own context, so things like changing
+directories does not "stick" between commands. If that behavior is required, an external script should be called.
 
-See also:
-[Service Commands](/setting-up-services/how-to-set-up-services/leverage-service-commands/)
-and
+See also: [Service Commands](/setting-up-services/how-to-set-up-services/leverage-service-commands/) and
 [Building a Preview -> The build process: explained](/building-a-preview/preview-deep-dive/how-previews-work/#the-build-process-explained)
 
 | Stage  | Description                                                                                            |
@@ -150,15 +137,13 @@ and
 
 The `init`, `update`, and `build` stages are related as follows:
 
-- When a Preview is created, the commands in `init` are run, followed by the
-  commands in `update`, and finally the commands in `build`.
+- When a Preview is created, the commands in `init` are run, followed by the commands in `update`, and finally the
+  commands in `build`.
 
-- When a Preview is
-  [refreshed](/building-a-preview/administer-previews/change-or-update-previews/#refresh-previews),
+- When a Preview is [refreshed](/building-a-preview/administer-previews/change-or-update-previews/#refresh-previews),
   the commands in `update` are run, followed by the commands in `build`.
 
-- When a Preview is created from a Base Preview, only the commands in `build`
-  are run.
+- When a Preview is created from a Base Preview, only the commands in `build` are run.
 
 ---
 
@@ -168,11 +153,9 @@ The `init`, `update`, and `build` stages are related as follows:
 - **Default:** `false` (`true` if only one service is defined)
 - **Required:** Yes, if more than one service is defined.
 
-Whether this is the
-[default Service](/setting-up-services/how-to-set-up-services/define-a-default-service/)
-for a Preview. The default Service is where incoming HTTP requests to the
-preview URL are routed. Setting this to true also implies `expose: 80` and
-`checkout: true` unless those attributes are explicitly set otherwise.
+Whether this is the [default Service](/setting-up-services/how-to-set-up-services/define-a-default-service/) for a
+Preview. The default Service is where incoming HTTP requests to the preview URL are routed. Setting this to true also
+implies `expose: 80` and `checkout: true` unless those attributes are explicitly set otherwise.
 
 ---
 
@@ -182,11 +165,9 @@ preview URL are routed. Setting this to true also implies `expose: 80` and
 - **Default:** _no default_
 - **Required:** No
 
-Defines the order in which commands are executed between the defined Services.
-If one Service has a dependency on another, it will wait for that Service's
-commands to run before running its own commands. If not set, there is no
-guaranteed order in which Services will execute their commands relative to other
-Services.
+Defines the order in which commands are executed between the defined Services. If one Service has a dependency on
+another, it will wait for that Service's commands to run before running its own commands. If not set, there is no
+guaranteed order in which Services will execute their commands relative to other Services.
 
 ---
 
@@ -196,12 +177,10 @@ Services.
 - **Default:** _no default_
 - **Required:** No
 
-A custom domain to use when generating URLs for the Service. If `example.com` is
-used, for example, URLs for the service will resemble
-`http://pr123-token.example.com` or `http://preview.example.com/pr123-token/`,
-depending on the other configuration values. Note that using a custom domain
-will result in browsers issuing SSL/TLS certificate warnings when combined with
-`https: true`.
+A custom domain to use when generating URLs for the Service. If `example.com` is used, for example, URLs for the service
+will resemble `http://pr123-token.example.com` or `http://preview.example.com/pr123-token/`, depending on the other
+configuration values. Note that using a custom domain will result in browsers issuing SSL/TLS certificate warnings when
+combined with `https: true`.
 
 ---
 
@@ -211,8 +190,8 @@ will result in browsers issuing SSL/TLS certificate warnings when combined with
 - **Default:** _no default_ (`80` when `default: true` is set)
 - **Required:** No
 
-If this Service should be publicly accessible via HTTP/HTTPS, this is the port
-that the Tugboat Proxy will forward incoming requests to.
+If this Service should be publicly accessible via HTTP/HTTPS, this is the port that the Tugboat Proxy will forward
+incoming requests to.
 
 ---
 
@@ -222,9 +201,8 @@ that the Tugboat Proxy will forward incoming requests to.
 - **Default:** `false`
 - **Required:** No
 
-By default, Tugboat only generates HTTPS URLs and forces a redirect to HTTPS.
-Setting this value to `true` changes this behavior to allow access to this
-Service's URL directly via HTTP on port 80.
+By default, Tugboat only generates HTTPS URLs and forces a redirect to HTTPS. Setting this value to `true` changes this
+behavior to allow access to this Service's URL directly via HTTP on port 80.
 
 ---
 
@@ -234,10 +212,9 @@ Service's URL directly via HTTP on port 80.
 - **Default:** `true`
 - **Required:** No
 
-When `true`, this Service's URL is public accessible via HTTPS on port 443. In
-order to disable HTTPS for a Service URL, `https` must be set to `false`, and
-`http` must be set to `true`. If both `https` and `http` are set to `true`,
-you’ll get both `http` and `https` links.
+When `true`, this Service's URL is public accessible via HTTPS on port 443. In order to disable HTTPS for a Service URL,
+`https` must be set to `false`, and `http` must be set to `true`. If both `https` and `http` are set to `true`, you’ll
+get both `http` and `https` links.
 
 ---
 
@@ -248,8 +225,8 @@ you’ll get both `http` and `https` links.
 - **Required:** Yes
 
 The Docker image to use for this Service. Tugboat maintains a set of images on
-[Dockerhub](https://hub.docker.com/u/tugboatqa). These images all extend the
-official docker images, and are configured to work well with Tugboat. See also:
+[Dockerhub](https://hub.docker.com/u/tugboatqa). These images all extend the official docker images, and are configured
+to work well with Tugboat. See also:
 [Specify a Service image](/setting-up-services/how-to-set-up-services/specify-a-service-image/).
 
 ---
@@ -260,9 +237,8 @@ official docker images, and are configured to work well with Tugboat. See also:
 - **Default:** `false`
 - **Required:** No
 
-When `true`, the URL generated for this Service will be a subpath of the root
-Preview domain instead of a subdomain. Using a subpath URL is not common, but
-can solve problems with testing advertisements or using OAuth
+When `true`, the URL generated for this Service will be a subpath of the root Preview domain instead of a subdomain.
+Using a subpath URL is not common, but can solve problems with testing advertisements or using OAuth
 
 | subpath | URL Example                                                        |
 | :------ | :----------------------------------------------------------------- |
@@ -277,9 +253,8 @@ can solve problems with testing advertisements or using OAuth
 - **Default:** `true`
 - **Required:** No
 
-When `true`, and `subpath: true` is set, URLs are rewritten by the Tugboat Proxy
-to replace the Preview-specific path with `/` before being forwarded to the
-Service. When `false`, URLs are passed through as-is.
+When `true`, and `subpath: true` is set, URLs are rewritten by the Tugboat Proxy to replace the Preview-specific path
+with `/` before being forwarded to the Service. When `false`, URLs are passed through as-is.
 
 ---
 
@@ -289,17 +264,13 @@ Service. When `false`, URLs are passed through as-is.
 - **Default:** _no default_
 - **Required:** No
 
-A set of visual diffs that should be generated for the Service. These visual
-diffs are generated automatically when a Preview is created with a
-[base preview](/building-a-preview/work-with-base-previews/). They are then
-updated when the Preview is
-[refreshed](/building-a-preview/administer-previews/change-or-update-previews/#refresh-previews)
-or
+A set of visual diffs that should be generated for the Service. These visual diffs are generated automatically when a
+Preview is created with a [base preview](/building-a-preview/work-with-base-previews/). They are then updated when the
+Preview is [refreshed](/building-a-preview/administer-previews/change-or-update-previews/#refresh-previews) or
 [rebuilt](/building-a-preview/administer-previews/change-or-update-previews/#rebuild-previews).
 
-The visual diffs are specified by providing a list of _relative URLs_ to the
-Service. Each item in this list can be either a string, such as `/blog`, or a
-map overriding the following screenshot options:
+The visual diffs are specified by providing a list of _relative URLs_ to the Service. Each item in this list can be
+either a string, such as `/blog`, or a map overriding the following screenshot options:
 
 | Option    | Default    | Description                                                                                                                                              |
 | :-------- | :--------- | :------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -309,8 +280,8 @@ map overriding the following screenshot options:
 | waitUntil | `load`     | Which event to wait for before creating a screenshot of a page.                                                                                          |
 | fullPage  | `true`     | Disable this to use an alternate screenshot method that is more friendly to elements that have `vh` CSS styles                                           |
 
-The `waitUntil` option can be one of the following events. If a list of events
-is given, the screenshot is created after all of the listed events have fired
+The `waitUntil` option can be one of the following events. If a list of events is given, the screenshot is created after
+all of the listed events have fired
 
 | Event            | Description                                                                |
 | :--------------- | :------------------------------------------------------------------------- |
@@ -319,8 +290,6 @@ is given, the screenshot is created after all of the listed events have fired
 | networkidle0     | Fires when there are no more than 0 network connections for at least 500ms |
 | networkidle2     | Fires when there are no more than 2 network connections for at least 500ms |
 
-The visual diff URLs can optionally be grouped by [Service alias](#aliases),
-which is convenient when aliases have different URL structures. Group URLs by
-nesting them in a map with the name of the alias they belong to. The special
-`:default` alias can be used to create a group of URLs that should not use an
-alias.
+The visual diff URLs can optionally be grouped by [Service alias](#aliases), which is convenient when aliases have
+different URL structures. Group URLs by nesting them in a map with the name of the alias they belong to. The special
+`:default` alias can be used to create a group of URLs that should not use an alias.

--- a/content/reference/tugboat-images.md
+++ b/content/reference/tugboat-images.md
@@ -5,23 +5,18 @@ weight: 6
 ---
 
 Tugboat maintains several Docker images. These images are extensions of
-[official Docker images](https://docs.docker.com/docker-hub/official_repos) and
-include tools and configurations that help them work well with Tugboat.
-Tugboat's images track the upstream images.
+[official Docker images](https://docs.docker.com/docker-hub/official_repos) and include tools and configurations that
+help them work well with Tugboat. Tugboat's images track the upstream images.
 
-All of our images are available on
-[Docker Hub](https://hub.docker.com/u/tugboatqa/). The source code used to
-generate these images is available on
-[GitHub](https://github.com/TugboatQA/images).
+All of our images are available on [Docker Hub](https://hub.docker.com/u/tugboatqa/). The source code used to generate
+these images is available on [GitHub](https://github.com/TugboatQA/images).
 
-It is best practice to use the most specific tag available for a given image to
-prevent any unforeseen upstream changes from affecting your Previews. For
-example, instead of `tugboatqa/mysql:5`, it is generally better to use
+It is best practice to use the most specific tag available for a given image to prevent any unforeseen upstream changes
+from affecting your Previews. For example, instead of `tugboatqa/mysql:5`, it is generally better to use
 `tugboatqa/mysql:5.6`.
 
-That said, sometimes the version of a Service doesn't really matter much. For
-example, it may not matter which version of memcached you use, and you can be
-sure you always have the most recent version available by specifying
+That said, sometimes the version of a Service doesn't really matter much. For example, it may not matter which version
+of memcached you use, and you can be sure you always have the most recent version available by specifying
 `tugboatqa/memcached` or `tugboatqa/memcached:latest`. See also:
 [Image version tags](/setting-up-services/service-images/image-version-tags/)
 
@@ -53,30 +48,26 @@ sure you always have the most recent version available by specifying
 
 #### Alpine
 
-The Alpine image is extremely minimal by nature. Unlike the other images, it
-does not have any extra tools installed except those required to use git with
-SSH.
+The Alpine image is extremely minimal by nature. Unlike the other images, it does not have any extra tools installed
+except those required to use git with SSH.
 
 #### Elastic Search
 
 The 2.x tags of this image extend the official Elast Search image on
-[Docker Hub](https://hub.docker.com/_/elasticsearch/). These images are based on
-Debian.
+[Docker Hub](https://hub.docker.com/_/elasticsearch/). These images are based on Debian.
 
-The newer tags of this image extend the official Elastic Search images
-maintained by [Elastic.co](https://www.docker.elastic.co/). These images are
-based on CentOS.
+The newer tags of this image extend the official Elastic Search images maintained by
+[Elastic.co](https://www.docker.elastic.co/). These images are based on CentOS.
 
 #### MySQL/MariaDB/Percona
 
-The MySQL, MariaDB, and Percona images are configured the same way. Each have a
-default database named `tugboat` as well as a user named `tugboat` with a
-password of `tugboat`. The `tugboat` user has full access to the `tugboat`
-database. In addition, the `root` database user does not have a password, but
-can only be used to connect to the database from the MariaDB or MySQL service.
+The MySQL, MariaDB, and Percona images are configured the same way. Each have a default database named `tugboat` as well
+as a user named `tugboat` with a password of `tugboat`. The `tugboat` user has full access to the `tugboat` database. In
+addition, the `root` database user does not have a password, but can only be used to connect to the database from the
+MariaDB or MySQL service.
 
-This means that in order to do any root-level database operations, they must be
-done by the commands defined for the MySQL or MariaDB service.
+This means that in order to do any root-level database operations, they must be done by the commands defined for the
+MySQL or MariaDB service.
 
 ```yaml
 services:
@@ -91,13 +82,11 @@ services:
 
 ##### PHP Extensions
 
-The PHP images provided [upstream](https://hub.docker.com/_/php/) do not use
-apt-get to install PHP extensions. Instead, there are helper scripts that let
-you install additional extensions as required. The images provided by Tugboat
-attempt to balance installing the most commonly used extensions with reserving
-as much disk space as possible. If an extension that you need is not installed,
-use `docker-php-ext-configure`, `docker-php-ext-install`, and
-`docker-php-ext-enable` in your Service commands.
+The PHP images provided [upstream](https://hub.docker.com/_/php/) do not use apt-get to install PHP extensions. Instead,
+there are helper scripts that let you install additional extensions as required. The images provided by Tugboat attempt
+to balance installing the most commonly used extensions with reserving as much disk space as possible. If an extension
+that you need is not installed, use `docker-php-ext-configure`, `docker-php-ext-install`, and `docker-php-ext-enable` in
+your Service commands.
 
 ```yaml
 commands:
@@ -112,9 +101,8 @@ More information about these helper scripts can be found in the
 
 ##### Apache Modules
 
-In order to keep the service containers as lean as possible, only the most basic
-apache modules are enabled in the PHP/Apache images. To enable a missing module,
-add it with a service command
+In order to keep the service containers as lean as possible, only the most basic apache modules are enabled in the
+PHP/Apache images. To enable a missing module, add it with a service command
 
 ```yaml
 commands:

--- a/content/setting-up-services/_index.md
+++ b/content/setting-up-services/_index.md
@@ -14,8 +14,7 @@ How to set up Services, and more about images.
 
 {{% children depth="3" %}}
 
-A Tugboat Service plays the role of what a server might provide in a production
-environment. A service can be a web server, a database server, a cache store,
-etc. Services form the core of your
-[Config file](/setting-up-tugboat/create-a-tugboat-config-file/), working
-together to build a [Preview](/building-a-preview/).
+A Tugboat Service plays the role of what a server might provide in a production environment. A service can be a web
+server, a database server, a cache store, etc. Services form the core of your
+[Config file](/setting-up-tugboat/create-a-tugboat-config-file/), working together to build a
+[Preview](/building-a-preview/).

--- a/content/setting-up-services/how-to-set-up-services/_index.md
+++ b/content/setting-up-services/how-to-set-up-services/_index.md
@@ -10,7 +10,6 @@ pre = "<b></b>"
 
 # How to Set Up Services
 
-Taking you step-by-step through the process to set up Services in your
-config.yml file.
+Taking you step-by-step through the process to set up Services in your config.yml file.
 
 {{% children  %}}

--- a/content/setting-up-services/how-to-set-up-services/clone-git-repositories-into-your-services.md
+++ b/content/setting-up-services/how-to-set-up-services/clone-git-repositories-into-your-services.md
@@ -4,13 +4,11 @@ date = 2019-09-19T13:04:53-04:00
 weight = 7
 +++
 
-When Tugboat runs, it clones your git repository into
-[your `default` Service](../define-a-default-service/). Optionally, you can also
-clone a copy of your git repository into other Services.
+When Tugboat runs, it clones your git repository into [your `default` Service](../define-a-default-service/).
+Optionally, you can also clone a copy of your git repository into other Services.
 
-To explicitly request that a Service has access to the git repository, specify
-the `checkout` key in the Service definition. This is especially useful if there
-are Service-specific scripts or test data files committed to your git
+To explicitly request that a Service has access to the git repository, specify the `checkout` key in the Service
+definition. This is especially useful if there are Service-specific scripts or test data files committed to your git
 repository.
 
 ```yaml
@@ -23,8 +21,6 @@ services:
     checkout: true
 ```
 
-In this example, both the `apache` and `mysql` services get a clone of the git
-repository, checked out to the git branch, tag, commit, or pull request that the
-preview is created for. The path where the git repository is cloned is available
-in an [environment variable](/reference/environment-variables/) named
-`$TUGBOAT_ROOT`.
+In this example, both the `apache` and `mysql` services get a clone of the git repository, checked out to the git
+branch, tag, commit, or pull request that the preview is created for. The path where the git repository is cloned is
+available in an [environment variable](/reference/environment-variables/) named `$TUGBOAT_ROOT`.

--- a/content/setting-up-services/how-to-set-up-services/custom-environment-variables.md
+++ b/content/setting-up-services/how-to-set-up-services/custom-environment-variables.md
@@ -4,30 +4,25 @@ date: 2019-09-26T15:39:08-04:00
 weight: 9
 ---
 
-Sometimes there are "secret" values or other data that you want to be made
-available to a Preview, but you don't want to commit that data to git, and for
-security reasons, you don't want to host it somewhere that Tugboat can grab it.
-These secret values usually include things like API keys to 3rd party services,
-or values used to encrypt session cookies that need to be unique to Tugboat but
-shared between your Previews.
+Sometimes there are "secret" values or other data that you want to be made available to a Preview, but you don't want to
+commit that data to git, and for security reasons, you don't want to host it somewhere that Tugboat can grab it. These
+secret values usually include things like API keys to 3rd party services, or values used to encrypt session cookies that
+need to be unique to Tugboat but shared between your Previews.
 
-Tugboat provides a convenient way of injecting these values into a Preview's
-services via custom environment variables. These variables can be found on the
-[Repository Settings](/setting-up-tugboat/select-repo-settings/#change-repository-settings)
-page.
+Tugboat provides a convenient way of injecting these values into a Preview's services via custom environment variables.
+These variables can be found on the
+[Repository Settings](/setting-up-tugboat/select-repo-settings/#change-repository-settings) page.
 
 ![Environment Variable Configuration](/_images/envvars-config.png)
 
-Like the other environment variables that Tugboat provides, the variables
-entered here are available to your Previews both while they are building as well
-as while they are running.
+Like the other environment variables that Tugboat provides, the variables entered here are available to your Previews
+both while they are building as well as while they are running.
 
 ### Storing Complex Data
 
-Environment variables are good at storing simple string values. However, what if
-you need to store something more complex, like an encoded JSON string, or the
-contents of an arbitrary file? One way of accomplishing that is to base64 encode
-the value, and then decode the value with a
+Environment variables are good at storing simple string values. However, what if you need to store something more
+complex, like an encoded JSON string, or the contents of an arbitrary file? One way of accomplishing that is to base64
+encode the value, and then decode the value with a
 [configuration file command](/reference/tugboat-configuration/#commands).
 
 ```sh
@@ -35,8 +30,8 @@ $ cat file | base64
 Q2h1Z2dhIENodWdnYSBUdWdib2F0IQo=
 ```
 
-Store that value into an environment variable. Then, extract it to a file you
-can use in your Preview with something like the following:
+Store that value into an environment variable. Then, extract it to a file you can use in your Preview with something
+like the following:
 
 ```sh
 echo $VAR | base64 -D > /tmp/file

--- a/content/setting-up-services/how-to-set-up-services/define-a-default-service.md
+++ b/content/setting-up-services/how-to-set-up-services/define-a-default-service.md
@@ -4,16 +4,13 @@ date = 2019-09-19T13:04:10-04:00
 weight = 4
 +++
 
-Every [Config file](/setting-up-tugboat/create-a-tugboat-config-file/) requires
-a default Service. The default Service is where HTTP requests are routed when a
-[Preview's URL](/building-a-preview/share-a-preview/) is visited by a user.
+Every [Config file](/setting-up-tugboat/create-a-tugboat-config-file/) requires a default Service. The default Service
+is where HTTP requests are routed when a [Preview's URL](/building-a-preview/share-a-preview/) is visited by a user.
 
-If your Config file only has one Service, that Service automatically becomes the
-default Service.
+If your Config file only has one Service, that Service automatically becomes the default Service.
 
-If your Config file contains multiple Services, you must designate one of them
-as the `default`. Specify a default Service by adding a `default` key to the
-Service, with a value of `true`.
+If your Config file contains multiple Services, you must designate one of them as the `default`. Specify a default
+Service by adding a `default` key to the Service, with a value of `true`.
 
 ```yaml
 services:
@@ -24,11 +21,8 @@ services:
     image: tugboatqa/mysql:5.6
 ```
 
-{{% notice note %}} Setting a Service as the `default` - including when the
-Service is automatically designated `default` because it's the only Service -
-also implies that port 80 is exposed to the Tugboat Proxy, and that the git
-repository is cloned to /var/lib/tugboat. To override the Service HTTP port,
-see: [Expose a Service HTTP port](../expose-a-service-http-port/). To override
-the git repository clone destination, see:
-[Clone Git repositories into your Services](../clone-git-repositories-into-your-services/).
-{{% /notice %}}
+{{% notice note %}} Setting a Service as the `default` - including when the Service is automatically designated
+`default` because it's the only Service - also implies that port 80 is exposed to the Tugboat Proxy, and that the git
+repository is cloned to /var/lib/tugboat. To override the Service HTTP port, see:
+[Expose a Service HTTP port](../expose-a-service-http-port/). To override the git repository clone destination, see:
+[Clone Git repositories into your Services](../clone-git-repositories-into-your-services/). {{% /notice %}}

--- a/content/setting-up-services/how-to-set-up-services/expose-a-service-http-port.md
+++ b/content/setting-up-services/how-to-set-up-services/expose-a-service-http-port.md
@@ -9,8 +9,8 @@ Every Service in a Preview gets a unique URL. That URL is accessible if:
 - An HTTP service is running on the Service, AND;
 - The port is exposed to the Tugboat Proxy.
 
-To expose a port, include an `expose` key in the Service definition with the
-port number that the HTTP service is listening on.
+To expose a port, include an `expose` key in the Service definition with the port number that the HTTP service is
+listening on.
 
 ```yaml
 services:
@@ -19,14 +19,12 @@ services:
     expose: 3000
 ```
 
-In this example, the Tugboat Proxy forwards requests to the service's URL
-through to a nodejs service running on port 3000.
+In this example, the Tugboat Proxy forwards requests to the service's URL through to a nodejs service running on
+port 3000.
 
-There are other options that affect how the proxy routing is handled. These
-advanced options can usually be left to their default settings. Check out our
-[Tugboat Configuration reference](/reference/tugboat-configuration/) for a
+There are other options that affect how the proxy routing is handled. These advanced options can usually be left to
+their default settings. Check out our [Tugboat Configuration reference](/reference/tugboat-configuration/) for a
 complete list.
 
-{{% notice note %}} When a Service is set as the `default`, port 80 is
-automatically exposed. You can override this by using the `expose` key to
-explicitly set an alternate port. {{% /notice %}}
+{{% notice note %}} When a Service is set as the `default`, port 80 is automatically exposed. You can override this by
+using the `expose` key to explicitly set an alternate port. {{% /notice %}}

--- a/content/setting-up-services/how-to-set-up-services/leverage-service-commands.md
+++ b/content/setting-up-services/how-to-set-up-services/leverage-service-commands.md
@@ -4,36 +4,29 @@ date = 2019-09-19T13:03:56-04:00
 weight = 3
 +++
 
-While technically optional, Service Commands are arguably the most powerful part
-of the [configuration file](/setting-up-tugboat/create-a-tugboat-config-file/).
-This is the set of commands that Tugboat runs in a Service container while
-creating a Preview.
+While technically optional, Service Commands are arguably the most powerful part of the
+[configuration file](/setting-up-tugboat/create-a-tugboat-config-file/). This is the set of commands that Tugboat runs
+in a Service container while creating a Preview.
 
-The service commands are separated into a set of stages: `init`, `update`, and
-`build`. Each stage represents an optional set of commands that Tugboat should
-run during that stage. For more info on the stages in the Preview build process,
-check out:
+The service commands are separated into a set of stages: `init`, `update`, and `build`. Each stage represents an
+optional set of commands that Tugboat should run during that stage. For more info on the stages in the Preview build
+process, check out:
 [the build process: explained](/building-a-preview/preview-deep-dive/how-previews-work/#the-build-process-explained).
 
-It may help to think of the stages as groups of commands with a particular
-purpose. While not enforced in any way, the stages roughly represent the
-following purposes:
+It may help to think of the stages as groups of commands with a particular purpose. While not enforced in any way, the
+stages roughly represent the following purposes:
 
-- **init** - Run commands that set up the basic Preview infrastructure. This
-  might include things like installing required packages or tools, or overriding
-  default configuration files.
+- **init** - Run commands that set up the basic Preview infrastructure. This might include things like installing
+  required packages or tools, or overriding default configuration files.
 
-- **update** - Run commands that import data or other assets into a Service.
-  This might include things like importing a database, or syncing image files
-  into a service.
+- **update** - Run commands that import data or other assets into a Service. This might include things like importing a
+  database, or syncing image files into a service.
 
-- **build** - Run commands that build or generate the actual site. This might
-  include things like compiling Sass files, updating 3rd party libraries, or
-  running database updates that the current code in the preview depends on.
+- **build** - Run commands that build or generate the actual site. This might include things like compiling Sass files,
+  updating 3rd party libraries, or running database updates that the current code in the preview depends on.
 
-{{% notice info %}} Each command is run in its own context, meaning things like
-`cd` do not "stick" between commands. If that behavior is required, an external
-script should be included in the git repository and called from the config file.
+{{% notice info %}} Each command is run in its own context, meaning things like `cd` do not "stick" between commands. If
+that behavior is required, an external script should be included in the git repository and called from the config file.
 {{% /notice %}}
 
 ```yaml
@@ -58,6 +51,5 @@ services:
         - zcat /tmp/mysqldump.sql.gz | mysql tugboat
 ```
 
-Notice that each stage is optional for a given service. There may not be any
-commands required for that service during some stage. When that is the case, the
-stage can be excluded completely.
+Notice that each stage is optional for a given service. There may not be any commands required for that service during
+some stage. When that is the case, the stage can be excluded completely.

--- a/content/setting-up-services/how-to-set-up-services/name-your-service.md
+++ b/content/setting-up-services/how-to-set-up-services/name-your-service.md
@@ -4,9 +4,8 @@ date = 2019-09-19T13:03:33-04:00
 weight = 1
 +++
 
-The top level of your
-[Config file](/setting-up-tugboat/create-a-tugboat-config-file/) is a `services`
-key whose value is a list of Services.
+The top level of your [Config file](/setting-up-tugboat/create-a-tugboat-config-file/) is a `services` key whose value
+is a list of Services.
 
 ```yaml
 services:
@@ -15,16 +14,13 @@ services:
   service3:
 ```
 
-Service names are arbitrary, but they act as the internal host name for the
-Service. This is the name other Services in the Preview would use to refer to
-the Service. As a result, there are a few rules you must observe when naming
-Services:
+Service names are arbitrary, but they act as the internal host name for the Service. This is the name other Services in
+the Preview would use to refer to the Service. As a result, there are a few rules you must observe when naming Services:
 
 - Service names may only include the characters `a-z`, `0-9`, and `-`.
 - Service names are limited to 39 characters.
 
-As an example, a set of Services that serve a PHP-based site with a MySQL
-database and a Redis cache might be:
+As an example, a set of Services that serve a PHP-based site with a MySQL database and a Redis cache might be:
 
 ```yaml
 services:

--- a/content/setting-up-services/how-to-set-up-services/running-a-background-process.md
+++ b/content/setting-up-services/how-to-set-up-services/running-a-background-process.md
@@ -4,23 +4,19 @@ date = 2019-09-19T13:05:11-04:00
 weight = 8
 +++
 
-A long-running background process in Tugboat needs some special care. If you try
-to add a background-process to your
-[config file](/setting-up-tugboat/create-a-tugboat-config-file/) in the
-conventional way, Tugboat will think the Preview has not finished building, and
-it will be stuck in the "building" state until it eventually times out and
-fails.
+A long-running background process in Tugboat needs some special care. If you try to add a background-process to your
+[config file](/setting-up-tugboat/create-a-tugboat-config-file/) in the conventional way, Tugboat will think the Preview
+has not finished building, and it will be stuck in the "building" state until it eventually times out and fails.
 
-{{% notice info %}} The reason Tugboat needs to wait for all of the `build`
-commands to finish is that we stop the Services after a Preview build is
-finished in order to take a snapshot. {{% /notice %}}
+{{% notice info %}} The reason Tugboat needs to wait for all of the `build` commands to finish is that we stop the
+Services after a Preview build is finished in order to take a snapshot. {{% /notice %}}
 
-Our [prebuilt images](../../service-images/using-tugboat-images/) use
-[runit](http://smarden.org/runit/) to start and manage background processes.
+Our [prebuilt images](../../service-images/using-tugboat-images/) use [runit](http://smarden.org/runit/) to start and
+manage background processes.
 
-To add your own background process that starts when the Service starts, create a
-directory in `/etc/service/yourprocessname` and a script at
-`/etc/service/yourprocessname/run` to tell `runit` how to start your process.
+To add your own background process that starts when the Service starts, create a directory in
+`/etc/service/yourprocessname` and a script at `/etc/service/yourprocessname/run` to tell `runit` how to start your
+process.
 
 For example, the following `run` script would start Apache:
 
@@ -29,9 +25,8 @@ For example, the following `run` script would start Apache:
 exec httpd-foreground
 ```
 
-Below is an example of how you might configure a NodeJS process to start. Keep
-in mind that `runit` will try to start the process as soon as the `run` script
-is present in the Service directory. So, set it up after any other build steps
+Below is an example of how you might configure a NodeJS process to start. Keep in mind that `runit` will try to start
+the process as soon as the `run` script is present in the Service directory. So, set it up after any other build steps
 that it might depend on.
 
 ```yaml

--- a/content/setting-up-services/how-to-set-up-services/services-in-action.md
+++ b/content/setting-up-services/how-to-set-up-services/services-in-action.md
@@ -4,13 +4,10 @@ date: 2019-09-17T11:27:02-04:00
 weight: 11
 ---
 
-Now that we've gone through all the components you'll need to set up Services
-for your Tugboat, let's take a look at an example
-[config file](/setting-up-tugboat/create-a-tugboat-config-file/) so you can see
-Services in action. This config file is for a
-[Drupal 8](/starter-configs/tutorials/drupal-8/) site, but you can check out our
-[starter configuration files](/starter-configs/) to see if we've got a code
-example to kick-start your setup.
+Now that we've gone through all the components you'll need to set up Services for your Tugboat, let's take a look at an
+example [config file](/setting-up-tugboat/create-a-tugboat-config-file/) so you can see Services in action. This config
+file is for a [Drupal 8](/starter-configs/tutorials/drupal-8/) site, but you can check out our
+[starter configuration files](/starter-configs/) to see if we've got a code example to kick-start your setup.
 
 ```yaml
 services:
@@ -37,8 +34,7 @@ services:
         - a2enmod headers rewrite
 
         # Install drush-launcher
-        - wget -O /usr/local/bin/drush
-          https://github.com/drush-ops/drush-launcher/releases/download/0.6.0/drush.phar
+        - wget -O /usr/local/bin/drush https://github.com/drush-ops/drush-launcher/releases/download/0.6.0/drush.phar
         - chmod +x /usr/local/bin/drush
 
         # Link the document root to the expected path. This example links /web
@@ -51,12 +47,10 @@ services:
       # already be present.
       update:
         # Use the tugboat-specific Drupal settings
-        - cp "${TUGBOAT_ROOT}/.tugboat/settings.local.php"
-          "${DOCROOT}/sites/default/"
+        - cp "${TUGBOAT_ROOT}/.tugboat/settings.local.php" "${DOCROOT}/sites/default/"
 
         # Generate a unique hash_salt to secure the site
-        - echo "\$settings['hash_salt'] = '$(openssl rand -hex 32)';" >>
-          "${DOCROOT}/sites/default/settings.local.php"
+        - echo "\$settings['hash_salt'] = '$(openssl rand -hex 32)';" >> "${DOCROOT}/sites/default/settings.local.php"
 
         # Install/update packages managed by composer, including drush
         - composer install --no-ansi
@@ -64,8 +58,7 @@ services:
         # Copy the files directory from an external server. The public
         # SSH key found in the Tugboat Repository configuration must be
         # copied to the external server in order to use rsync over SSH.
-        - rsync -av --delete user@example.com:/path/to/files/
-          "${DOCROOT}/sites/default/files/"
+        - rsync -av --delete user@example.com:/path/to/files/ "${DOCROOT}/sites/default/files/"
         - chgrp -R www-data "${DOCROOT}/sites/default/files"
         - find "${DOCROOT}/sites/default/files" -type d -exec chmod 2775 {} \;
         - find "${DOCROOT}/sites/default/files" -type f -exec chmod 0664 {} \;
@@ -77,8 +70,7 @@ services:
         # This results in smaller previews and reduces the build time.
         - drush -r "${DOCROOT}" pm-download stage_file_proxy
         - drush -r "${DOCROOT}" pm-enable --yes stage_file_proxy
-        - drush -r "${DOCROOT}" variable-set stage_file_proxy_origin
-          "http://www.example.com"
+        - drush -r "${DOCROOT}" variable-set stage_file_proxy_origin "http://www.example.com"
 
       # Commands that build the site. This is where you would add things
       # like feature reverts or any other drush commands required to

--- a/content/setting-up-services/how-to-set-up-services/set-the-document-root-path.md
+++ b/content/setting-up-services/how-to-set-up-services/set-the-document-root-path.md
@@ -4,21 +4,17 @@ date = 2019-09-19T13:04:39-04:00
 weight = 6
 +++
 
-Tugboat does not try to guess where your document root lives in your repository.
-Likewise, it does not try to guess where a web server image expects to serve the
-default document root from. This means you are responsible for making this link
-in your [configuration file](/setting-up-tugboat/create-a-tugboat-config-file/)
+Tugboat does not try to guess where your document root lives in your repository. Likewise, it does not try to guess
+where a web server image expects to serve the default document root from. This means you are responsible for making this
+link in your [configuration file](/setting-up-tugboat/create-a-tugboat-config-file/)
 
-Each web server image expects the document root to be in a different location.
-This is a side effect of using the
-[Official Docker Images](https://docs.docker.com/docker-hub/official_repos/).
-The [images provided by Tugboat](../../service-images/using-tugboat-images/)
-store this document root location in an environment variable named `$DOCROOT`
-for convenience.
+Each web server image expects the document root to be in a different location. This is a side effect of using the
+[Official Docker Images](https://docs.docker.com/docker-hub/official_repos/). The
+[images provided by Tugboat](../../service-images/using-tugboat-images/) store this document root location in an
+environment variable named `$DOCROOT` for convenience.
 
-Use this configuration to link the document root to a directory named `/docroot`
-in your git repository. This works for the following images provided by Tugboat:
-`tugboatqa/httpd`, `tugboatqa/nginx`, `tugboatqa/php:apache`
+Use this configuration to link the document root to a directory named `/docroot` in your git repository. This works for
+the following images provided by Tugboat: `tugboatqa/httpd`, `tugboatqa/nginx`, `tugboatqa/php:apache`
 
 ```yaml
 services:

--- a/content/setting-up-services/how-to-set-up-services/specify-a-service-image.md
+++ b/content/setting-up-services/how-to-set-up-services/specify-a-service-image.md
@@ -4,8 +4,7 @@ date = 2019-09-19T13:03:46-04:00
 weight = 2
 +++
 
-Because Tugboat uses Docker under the hood, every Service in your config file
-must use a
+Because Tugboat uses Docker under the hood, every Service in your config file must use a
 [valid Docker image address](https://docs.docker.com/engine/reference/commandline/pull/).
 
 Here's what you need to know about working with Service images in Tugboat:
@@ -15,8 +14,7 @@ Here's what you need to know about working with Service images in Tugboat:
 
 If you want to pull a Docker image that isn't public, you'll need to
 [authenticate with the Docker Registry](/setting-up-tugboat/select-repo-settings/#authenticate-with-a-docker-registry)
-from your project's
-[Repository Settings](/setting-up-tugboat/select-repo-settings/#change-repository-settings).
+from your project's [Repository Settings](/setting-up-tugboat/select-repo-settings/#change-repository-settings).
 
 For a deeper dive on Service images in Tugboat, check out:
 
@@ -25,20 +23,17 @@ For a deeper dive on Service images in Tugboat, check out:
 - [Using a Docker image to mirror your production services](../../service-images/mirror-production-with-image/)
 - [When does an image get pulled or updated?](../../service-images/docker-pull/)
 
-{{% notice info %}} Tugboat has abstracted away some of the technical aspects of
-working with Docker images, but if you're new to Docker, and want to understand
-more about Docker images,
+{{% notice info %}} Tugboat has abstracted away some of the technical aspects of working with Docker images, but if
+you're new to Docker, and want to understand more about Docker images,
 [check out Docker's documentation](https://docs.docker.com/v17.09/engine/userguide/storagedriver/imagesandcontainers/).
 {{% /notice %}}
 
 ### How to call a Service image from Docker Hub
 
-Tugboat's default image registry is [Docker Hub](https://hub.docker.com/). When
-you use an `image` key in the Service definition, Tugboat pulls the
-corresponding image from Docker Hub.
+Tugboat's default image registry is [Docker Hub](https://hub.docker.com/). When you use an `image` key in the Service
+definition, Tugboat pulls the corresponding image from Docker Hub.
 
-To call a Service image from Docker Hub, specify an `image` key in the Service
-definition.
+To call a Service image from Docker Hub, specify an `image` key in the Service definition.
 
 For example:
 
@@ -54,24 +49,22 @@ To dissect the key value in our Apache image key example above, we're calling:
 
 `tugboatqa` : Profile of the image provider on Docker Hub; in this case, it's
 [TugboatQA](https://hub.docker.com/u/tugboatqa), the organization.  
-`httpd` : This is the specific image we're calling; in this case, it's Tugboat's
-version of the [Apache HTTP Server](https://hub.docker.com/r/tugboatqa/httpd).  
-`2.4` : **OPTIONAL** version tag; in this case, we're calling for the specific
-2.4 version of Tugboat's Apache HTTP server image. If you browse to the
-[supported images in our GitHub repo](https://github.com/TugboatQA/dockerfiles/blob/master/httpd/TAGS.md),
-you can see a list of all the version tags available for Tugboat's Apache HTTP
-Server image.
+`httpd` : This is the specific image we're calling; in this case, it's Tugboat's version of the
+[Apache HTTP Server](https://hub.docker.com/r/tugboatqa/httpd).  
+`2.4` : **OPTIONAL** version tag; in this case, we're calling for the specific 2.4 version of Tugboat's Apache HTTP
+server image. If you browse to the
+[supported images in our GitHub repo](https://github.com/TugboatQA/dockerfiles/blob/master/httpd/TAGS.md), you can see a
+list of all the version tags available for Tugboat's Apache HTTP Server image.
 
 For more on version tags, take a look at our
 [Docker image version tags primer](../../service-images/image-version-tags/).
 
 ### How to use a Docker image from another registry
 
-If you want to use a Docker image from another registry, you'll need to specify
-the alternate registry, since Tugboat pulls from Docker Hub by default.
+If you want to use a Docker image from another registry, you'll need to specify the alternate registry, since Tugboat
+pulls from Docker Hub by default.
 
-For a full breakdown of how to pull from a different registry, check out
-Docker's Docs:
+For a full breakdown of how to pull from a different registry, check out Docker's Docs:
 [Pull from a different registry](https://docs.docker.com/engine/reference/commandline/pull/#pull-from-a-different-registry).
 
 An example of this in action at Tugboat might look like:

--- a/content/setting-up-services/service-images/_index.md
+++ b/content/setting-up-services/service-images/_index.md
@@ -10,7 +10,6 @@ pre = "<b></b>"
 
 # Service Images
 
-Details about Service images under the hood, including how to use your own
-Docker image and Tugboat-maintained images.
+Details about Service images under the hood, including how to use your own Docker image and Tugboat-maintained images.
 
 {{% children  %}}

--- a/content/setting-up-services/service-images/docker-pull.md
+++ b/content/setting-up-services/service-images/docker-pull.md
@@ -4,51 +4,40 @@ date: 2019-09-19T13:22:39-04:00
 weight: 5
 ---
 
-Familiar with Docker, and looking for more specific information about when
-images get pulled or updated in Tugboat? Here's what you need to know about
-`docker pull` under the hood:
+Familiar with Docker, and looking for more specific information about when images get pulled or updated in Tugboat?
+Here's what you need to know about `docker pull` under the hood:
 
 - [When does Tugboat pull a Docker image?](#when-does-tugboat-pull-a-docker-image)
 - [When does Tugboat update a Docker image?](#when-does-tugboat-update-a-docker-image)
 
 ## When does Tugboat pull a Docker image?
 
-Tugboat doesn't pull the images in your config file every time you open a pull
-request, or refresh a Preview; it only does a `docker pull` (under the hood)
-when:
+Tugboat doesn't pull the images in your config file every time you open a pull request, or refresh a Preview; it only
+does a `docker pull` (under the hood) when:
 
-- You [build a Preview](/building-a-preview/administer-previews/build-previews/)
-  from scratch (without using a Base Preview)
-- You
-  [Rebuild](/building-a-preview/administer-previews/change-or-update-previews/#rebuild-previews)
-  a Preview that was not built from a Base Preview
+- You [build a Preview](/building-a-preview/administer-previews/build-previews/) from scratch (without using a Base
+  Preview)
+- You [Rebuild](/building-a-preview/administer-previews/change-or-update-previews/#rebuild-previews) a Preview that was
+  not built from a Base Preview
 
-Otherwise, Tugboat relies on the images you pulled when the Preview was first
-created; Preview Actions like
+Otherwise, Tugboat relies on the images you pulled when the Preview was first created; Preview Actions like
 [Refreshing a Preview](/building-a-preview/administer-previews/change-or-update-previews/#refresh-previews),
-[Cloning a Preview](/building-a-preview/administer-previews/build-previews/#duplicate-a-preview),
-or
-[automatically generating a Preview from a pull request](/building-a-preview/automate-previews/auto-generate/)
-when you're using a Base Preview - those things all keep the Docker images you
-referenced when you first built the Preview.
+[Cloning a Preview](/building-a-preview/administer-previews/build-previews/#duplicate-a-preview), or
+[automatically generating a Preview from a pull request](/building-a-preview/automate-previews/auto-generate/) when
+you're using a Base Preview - those things all keep the Docker images you referenced when you first built the Preview.
 
 ## When does Tugboat update a Docker image?
 
-Because Tugboat pulls your Docker images at the beginning of the Preview build
-process, it won't `docker pull` an updated image unless you kick off the Preview
-build process from scratch again.
+Because Tugboat pulls your Docker images at the beginning of the Preview build process, it won't `docker pull` an
+updated image unless you kick off the Preview build process from scratch again.
 
 For more info, see:
 [Why Build phases matter](/building-a-preview/preview-deep-dive/how-previews-work/#why-build-phases-matter).
 
-{{% notice tip %}} If your Tugboat Preview isn't pulling your latest Docker
-image tag, it might be because you're building from a Base Preview. If that's
-the case, you'll need to
-[Rebuild your Base Preview](/building-a-preview/work-with-base-previews/change-or-update/#change-a-base-preview),
-which executes an API call to `docker pull` under the hood to grab the image tag
-referenced in your
-[config file](/setting-up-tugboat/create-a-tugboat-config-file). If that still
-doesn't get you the image you expect, check your config file to see which
-[image tag](../image-version-tags/) you're pulling; you may need to change the
-reference to latest, or a specific image tag, to get the result you want.
-{{% /notice %}}
+{{% notice tip %}} If your Tugboat Preview isn't pulling your latest Docker image tag, it might be because you're
+building from a Base Preview. If that's the case, you'll need to
+[Rebuild your Base Preview](/building-a-preview/work-with-base-previews/change-or-update/#change-a-base-preview), which
+executes an API call to `docker pull` under the hood to grab the image tag referenced in your
+[config file](/setting-up-tugboat/create-a-tugboat-config-file). If that still doesn't get you the image you expect,
+check your config file to see which [image tag](../image-version-tags/) you're pulling; you may need to change the
+reference to latest, or a specific image tag, to get the result you want. {{% /notice %}}

--- a/content/setting-up-services/service-images/image-version-tags.md
+++ b/content/setting-up-services/service-images/image-version-tags.md
@@ -16,8 +16,8 @@ services:
     image: tugboatqa/mysql:5.6
 ```
 
-In this example, we called versions `2.4` and `5.6` for the `httpd` and `mysql`
-images. These are Docker image version tags.
+In this example, we called versions `2.4` and `5.6` for the `httpd` and `mysql` images. These are Docker image version
+tags.
 
 You can specify version tags in a few different ways:
 
@@ -25,36 +25,31 @@ You can specify version tags in a few different ways:
 - [Major version tags](#major-version-tags)
 - [Latest version tags](#latest-version-tags)
 
-{{% notice note %}} If you don't need a specific version of a Service image, you
-can leave the tag off of the image call. When you don't specify a tag, you'll
-get the latest version of that image. However, because `latest` pulls the newest
-version of an image, it could introduce a breaking change, so we recommend
-specifying major/minor versions as needed. {{% /notice %}}
+{{% notice note %}} If you don't need a specific version of a Service image, you can leave the tag off of the image
+call. When you don't specify a tag, you'll get the latest version of that image. However, because `latest` pulls the
+newest version of an image, it could introduce a breaking change, so we recommend specifying major/minor versions as
+needed. {{% /notice %}}
 
-If you're not sure which version tag to use, you can always browse to the
-service image on [Docker Hub](https://hub.docker.com/) and check out what tags
-are available.
+If you're not sure which version tag to use, you can always browse to the service image on
+[Docker Hub](https://hub.docker.com/) and check out what tags are available.
 
 ![Browse image tags on Docker Hub](../../../_images/browse-tags-on-docker-hub.png)
 
 ## Point-release version tags:
 
-Using specific version tags helps prevent breaking changes that come along with
-incremental updates. In our example above, we've called `tugboatqa/mysql:5.6`
-instead of `tugboatqa/mysql:5`.
+Using specific version tags helps prevent breaking changes that come along with incremental updates. In our example
+above, we've called `tugboatqa/mysql:5.6` instead of `tugboatqa/mysql:5`.
 
 ## Major version tags
 
-If you want to make sure you're using a specific major version, but don't care
-about point releases, specify something like `tugboatqa/node:10` to ensure you
-always use the latest available minor release of node 10.x.
+If you want to make sure you're using a specific major version, but don't care about point releases, specify something
+like `tugboatqa/node:10` to ensure you always use the latest available minor release of node 10.x.
 
 ## Latest version tags
 
-In some cases, you're less likely to be worried about a specific version; for
-example, it may not matter which version of memcached you use.
+In some cases, you're less likely to be worried about a specific version; for example, it may not matter which version
+of memcached you use.
 
-When you don't need to call for a specific version of a Service, using the image
-name without a tag (`tugboatqa/memcached`), or the `latest` tag
-(`tugboatqa/memcached:latest`) will get you the most recent version of a Service
-image.
+When you don't need to call for a specific version of a Service, using the image name without a tag
+(`tugboatqa/memcached`), or the `latest` tag (`tugboatqa/memcached:latest`) will get you the most recent version of a
+Service image.

--- a/content/setting-up-services/service-images/mirror-production-with-image.md
+++ b/content/setting-up-services/service-images/mirror-production-with-image.md
@@ -4,20 +4,15 @@ date: 2019-09-19T13:22:09-04:00
 weight: 3
 ---
 
-Using a Docker image to mirror your production services in Tugboat works the
-same as pulling an image for any other Service in Tugboat. Follow the
-[steps to set up Services in Tugboat](/setting-up-services/how-to-set-up-services/),
-and specify your production image.
+Using a Docker image to mirror your production services in Tugboat works the same as pulling an image for any other
+Service in Tugboat. Follow the [steps to set up Services in Tugboat](/setting-up-services/how-to-set-up-services/), and
+specify your production image.
 
 As you'll probably be pulling from a private repository, you may need to first:
 
 1. [Authenticate with a Docker Registry](/setting-up-tugboat/select-repo-settings/#authenticate-with-a-docker-registry)
-   from Tugboat's
-   [Repository Settings](/setting-up-tugboat/select-repo-settings/#change-repository-settings).
-2. Take a look at
-   [using third-party Docker images with Tugboat](../third-party-docker-images/)
-   for info about caveats, as well as links to scripts you could use to optimize
-   your own image for Tugboat.
-3. If you're pulling from a private Docker repository that isn't on Docker Hub,
-   you'll need to follow the process in:
+   from Tugboat's [Repository Settings](/setting-up-tugboat/select-repo-settings/#change-repository-settings).
+2. Take a look at [using third-party Docker images with Tugboat](../third-party-docker-images/) for info about caveats,
+   as well as links to scripts you could use to optimize your own image for Tugboat.
+3. If you're pulling from a private Docker repository that isn't on Docker Hub, you'll need to follow the process in:
    [Bring your own Docker image from another registry](/setting-up-services/how-to-set-up-services/specify-a-service-image/#how-to-use-a-docker-image-from-another-registry).

--- a/content/setting-up-services/service-images/third-party-docker-images.md
+++ b/content/setting-up-services/service-images/third-party-docker-images.md
@@ -4,22 +4,17 @@ date: 2019-09-19T13:22:21-04:00
 weight: 4
 ---
 
-Theoretically, you can use any publicly available Docker image in your Tugboat
-build. However, you may run into a limitation that can make third-party Docker
-images problematic: Tugboat will not create a Service from an image that defines
-any VOLUMES. For that reason, we recommend sticking with the images built
-specifically for use with Tugboat.
+Theoretically, you can use any publicly available Docker image in your Tugboat build. However, you may run into a
+limitation that can make third-party Docker images problematic: Tugboat will not create a Service from an image that
+defines any VOLUMES. For that reason, we recommend sticking with the images built specifically for use with Tugboat.
 
-If you'd like to use your own Docker images, this repo contains the scripts we
-use to make an image Tugboat compatible: <https://github.com/TugboatQA/images>
+If you'd like to use your own Docker images, this repo contains the scripts we use to make an image Tugboat compatible:
+<https://github.com/TugboatQA/images>
 
-{{% notice info %}} Under the hood, Tugboat commits the entire state of the
-container (including files, databases, etc) to optimize Preview builds when it
-takes
-[the Build Snapshot](/building-a-preview/preview-deep-dive/how-previews-work/#the-build-snapshot).
-With a Build snapshot in place, a Preview built from a Base Preview only runs
-the `build` steps - without importing a database or other required assets. (For
-more info, take a look at:
+{{% notice info %}} Under the hood, Tugboat commits the entire state of the container (including files, databases, etc)
+to optimize Preview builds when it takes
+[the Build Snapshot](/building-a-preview/preview-deep-dive/how-previews-work/#the-build-snapshot). With a Build snapshot
+in place, a Preview built from a Base Preview only runs the `build` steps - without importing a database or other
+required assets. (For more info, take a look at:
 [the build process: explained.](/building-a-preview/preview-deep-dive/how-previews-work/#the-build-process-explained))
-Because of this, the concept of Docker volumes doesn’t really mesh with the way
-Tugboat uses images. {{% /notice %}}
+Because of this, the concept of Docker volumes doesn’t really mesh with the way Tugboat uses images. {{% /notice %}}

--- a/content/setting-up-services/service-images/using-tugboat-images.md
+++ b/content/setting-up-services/service-images/using-tugboat-images.md
@@ -4,23 +4,16 @@ date: 2019-09-19T13:21:53-04:00
 weight: 2
 ---
 
-Tugboat maintains several [prebuilt Docker images](/reference/tugboat-images/).
-These images are extensions of
-[official Docker images](https://docs.docker.com/docker-hub/official_repos/)
-that include tools and configurations that help them work well with Tugboat.
-Tugboat's images track the upstream images, meaning the `tugboat/httpd:2.4`
-image extends the latest official `httpd:2.4` image.
+Tugboat maintains several [prebuilt Docker images](/reference/tugboat-images/). These images are extensions of
+[official Docker images](https://docs.docker.com/docker-hub/official_repos/) that include tools and configurations that
+help them work well with Tugboat. Tugboat's images track the upstream images, meaning the `tugboat/httpd:2.4` image
+extends the latest official `httpd:2.4` image.
 
-For a complete list of Tugboat's images and tags, find us on
-[Docker Hub](https://hub.docker.com/u/tugboatqa/).
+For a complete list of Tugboat's images and tags, find us on [Docker Hub](https://hub.docker.com/u/tugboatqa/).
 
-You can check out the scripts we used to create these images on
-[GitHub](https://github.com/TugboatQA/images).
+You can check out the scripts we used to create these images on [GitHub](https://github.com/TugboatQA/images).
 
-{{% notice note %}} We add new
-[prebuilt service images](/reference/tugboat-images/) as users need them. If
-there is something you need that we have not yet added,
-[let us know](/support/), and we will work with you to try to get it added to
-the list. Alternatively, you are free to choose a generic service image, such as
-`debian`, `ubuntu`, or `centos`, and install any packages you might need.
-{{% /notice %}}
+{{% notice note %}} We add new [prebuilt service images](/reference/tugboat-images/) as users need them. If there is
+something you need that we have not yet added, [let us know](/support/), and we will work with you to try to get it
+added to the list. Alternatively, you are free to choose a generic service image, such as `debian`, `ubuntu`, or
+`centos`, and install any packages you might need. {{% /notice %}}

--- a/content/setting-up-tugboat/_index.md
+++ b/content/setting-up-tugboat/_index.md
@@ -14,7 +14,5 @@ Connecting Tugboat to your git provider, creating projects, adding repositories.
 
 {{% children  %}}
 
-{{% notice tip %}} If you want to learn more about setting up Tugboat and get a
-feel for the overall workflow, watch our
-[Getting Started with Tugboat video](https://www.youtube.com/watch?v=HYTsrm5ORmU)
-on YouTube. {{% /notice %}}
+{{% notice tip %}} If you want to learn more about setting up Tugboat and get a feel for the overall workflow, watch our
+[Getting Started with Tugboat video](https://www.youtube.com/watch?v=HYTsrm5ORmU) on YouTube. {{% /notice %}}

--- a/content/setting-up-tugboat/add-repos-to-the-project.md
+++ b/content/setting-up-tugboat/add-repos-to-the-project.md
@@ -4,41 +4,35 @@ date: 2019-09-17T11:42:01-04:00
 weight: 3
 ---
 
-Once you've decided how you want to structure your project, add the relevant
-repos to your project.
+Once you've decided how you want to structure your project, add the relevant repos to your project.
 
 ### To add repos during project creation:
 
-When you're creating a project, select your repository host from the Provider
-drop-down, select the Organization, if applicable, and click the radio button
-next to the repo you want to add.
+When you're creating a project, select your repository host from the Provider drop-down, select the Organization, if
+applicable, and click the radio button next to the repo you want to add.
 
 ![Select Provider and repo](../../_images/add-repos-to-project-select-repo.png)
 
-Alternately, if you're using a generic git server, select Git as the provider,
-and enter your repo name and Git URL.
+Alternately, if you're using a generic git server, select Git as the provider, and enter your repo name and Git URL.
 
 ![Specify generic git server](../../_images/add-repos-to-project-generic-git-provider.png)
 
 ### To add repos to a project you've already created:
 
-1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-   upper-right of the Tugboat screen.
+1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 2. Select the project where you want to add the repo.
 3. Go to {{% ui-text %}}Add a Repository{{% /ui-text %}} .
 
 From there, you'll be back to the 'select a provider and specify a repo' screen.
 
-{{% notice info %}} There is no limit to the number of repositories you can add
-to a Tugboat project. However, you may be unable to build new Previews within a
-project, if the total storage used in your project reaches the
+{{% notice info %}} There is no limit to the number of repositories you can add to a Tugboat project. However, you may
+be unable to build new Previews within a project, if the total storage used in your project reaches the
 [billing tier storage limit for your project](/tugboat-billing/tugboat-pricing/#how-does-tugboat-pricing-work).
 {{% /notice %}}
 
 {{%expand "Visual Walkthrough" %}}
 
-Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-upper-right of the Tugboat screen.
+Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 
 ![My Projects](../../_images/go-to-user-my-projects.png)
 

--- a/content/setting-up-tugboat/connect-with-your-provider.md
+++ b/content/setting-up-tugboat/connect-with-your-provider.md
@@ -18,12 +18,11 @@ weight: 1
 ### How do I link Tugboat to GitHub?
 
 1. Go to [Sign In](https://dashboard.tugboat.qa/) and select GitHub.
-2. Enter your GitHub Username and Password (or Create an Account), complete
-   Two-Factor Authentication.
+2. Enter your GitHub Username and Password (or Create an Account), complete Two-Factor Authentication.
 3. Authorize Tugboat.
 
-Once you complete GitHub authorization, you'll be redirected to the
-[Create a Tugboat Project](../create-a-new-project/) screen.
+Once you complete GitHub authorization, you'll be redirected to the [Create a Tugboat Project](../create-a-new-project/)
+screen.
 
 {{%expand "Visual Walkthrough" %}}
 
@@ -31,8 +30,7 @@ Go to [Sign In](https://dashboard.tugboat.qa/) and select GitHub.
 
 ![Select GitHub sign in](../../_images/github-sign-in.png)
 
-Enter your GitHub Username and Password (or Create an Account), complete
-Two-Factor Authentication.
+Enter your GitHub Username and Password (or Create an Account), complete Two-Factor Authentication.
 
 ![Sign in to GitHub](../../_images/github-sign-in-button.png)
 
@@ -40,8 +38,8 @@ Authorize Tugboat.
 
 ![Authorize Tugboat](../../_images/github-authorize-tugboat.png)
 
-Once you complete GitHub authorization, you'll be redirected to the
-[Create a Tugboat Project](../create-a-new-project/) screen.
+Once you complete GitHub authorization, you'll be redirected to the [Create a Tugboat Project](../create-a-new-project/)
+screen.
 
 ![Create a Tugboat Project](../../_images/create-a-tugboat-project-screen.png)
 
@@ -49,40 +47,31 @@ Once you complete GitHub authorization, you'll be redirected to the
 
 ### Using the GitHub integration
 
-The GitHub integration gives Tugboat the following features, which you can
-access in your Project -> Repository Settings:
+The GitHub integration gives Tugboat the following features, which you can access in your Project -> Repository
+Settings:
 
-- {{% ui-text %}}Build Pull Requests automatically{{% /ui-text %}} On by
-  default; Tugboat automatically creates a Preview when a GitHub pull request is
-  opened.
-- {{% ui-text %}}Rebuild updated Pull Requests automatically{{% /ui-text %}} On
-  by default; Tugboat automatically rebuilds a Preview when the corresponding
-  pull request is updated.
-- {{% ui-text %}}Delete Pull Request Previews automatically{{% /ui-text %}} On
-  by default; Tugboat automatically deletes a Preview when its pull request is
-  merged or closed.
-- {{% ui-text %}}Set Pull Request status{{% /ui-text %}} On by default; Tugboat
-  updates the pull request status to reflect the state of its Preview.
-- {{% ui-text %}}Set Pull Request deployment status{{% /ui-text %}} Off by
-  default; Tugboat adds a deployment update to the pull request when a Preview
-  is built.
-- {{% ui-text %}}Post Preview links in Pull Request comments{{% /ui-text %}} Off
-  by default; Tugboat adds a comment to a pull request with links to its
-  Preview. The comment author is the person who authenticated the git repo to
-  Tugboat; to change this, see:
+- {{% ui-text %}}Build Pull Requests automatically{{% /ui-text %}} On by default; Tugboat automatically creates a
+  Preview when a GitHub pull request is opened.
+- {{% ui-text %}}Rebuild updated Pull Requests automatically{{% /ui-text %}} On by default; Tugboat automatically
+  rebuilds a Preview when the corresponding pull request is updated.
+- {{% ui-text %}}Delete Pull Request Previews automatically{{% /ui-text %}} On by default; Tugboat automatically deletes
+  a Preview when its pull request is merged or closed.
+- {{% ui-text %}}Set Pull Request status{{% /ui-text %}} On by default; Tugboat updates the pull request status to
+  reflect the state of its Preview.
+- {{% ui-text %}}Set Pull Request deployment status{{% /ui-text %}} Off by default; Tugboat adds a deployment update to
+  the pull request when a Preview is built.
+- {{% ui-text %}}Post Preview links in Pull Request comments{{% /ui-text %}} Off by default; Tugboat adds a comment to a
+  pull request with links to its Preview. The comment author is the person who authenticated the git repo to Tugboat; to
+  change this, see:
   [Add a Tugboat Bot to your team](../../administer-tugboat-crew/user-admin/#add-a-tugboat-bot-to-your-team).
-- {{% ui-text %}}Build Previews for forked Pull Requests{{% /ui-text %}} Off by
-  default; Tugboat builds Previews for pull requests made to the primary repo
-  from forked repositories. **There are security implications from using this
-  setting:** any secrets in your Preview will be accessible by the owner of the
-  forked repository. When this feature is not enabled, forked pull requests show
-  as available to build (or will attempt to build automatically if you have
-  {{% ui-text %}}Build Pull Requests Automatically{{% /ui-text %}} enabled) but
-  the Preview build will fail.
+- {{% ui-text %}}Build Previews for forked Pull Requests{{% /ui-text %}} Off by default; Tugboat builds Previews for
+  pull requests made to the primary repo from forked repositories. **There are security implications from using this
+  setting:** any secrets in your Preview will be accessible by the owner of the forked repository. When this feature is
+  not enabled, forked pull requests show as available to build (or will attempt to build automatically if you have
+  {{% ui-text %}}Build Pull Requests Automatically{{% /ui-text %}} enabled) but the Preview build will fail.
 
-You can also specify the account from which comments are posted to GitHub in
-this section. For info on customizing this, see:
-[Add a Tugboat Bot to your team](../../administer-tugboat-crew/user-admin/#add-a-tugboat-bot-to-your-team).
+You can also specify the account from which comments are posted to GitHub in this section. For info on customizing this,
+see: [Add a Tugboat Bot to your team](../../administer-tugboat-crew/user-admin/#add-a-tugboat-bot-to-your-team).
 
 ## GitLab
 
@@ -95,8 +84,8 @@ this section. For info on customizing this, see:
 2. Enter your GitLab Username and Password (or Register).
 3. Authorize Tugboat.
 
-Once you complete GitLab authorization, you'll be redirected to the
-[Create a Tugboat Project](../create-a-new-project/) screen.
+Once you complete GitLab authorization, you'll be redirected to the [Create a Tugboat Project](../create-a-new-project/)
+screen.
 
 {{%expand "Visual Walkthrough" %}}
 
@@ -112,8 +101,8 @@ Authorize Tugboat.
 
 ![Authorize Tugboat](../../_images/gitlab-authorize-tugboat.png)
 
-Once you complete GitLab authorization, you'll be redirected to the
-[Create a Tugboat Project](../create-a-new-project/) screen.
+Once you complete GitLab authorization, you'll be redirected to the [Create a Tugboat Project](../create-a-new-project/)
+screen.
 
 ![Create a Tugboat Project](../../_images/create-a-tugboat-project-screen.png)
 
@@ -121,37 +110,29 @@ Once you complete GitLab authorization, you'll be redirected to the
 
 ### Using the GitLab integration
 
-The GitLab integration gives your Tugboat the following features, which you can
-access in your Project -> Repository Settings:
+The GitLab integration gives your Tugboat the following features, which you can access in your Project -> Repository
+Settings:
 
-- {{% ui-text %}}Build Merge Requests automatically{{% /ui-text %}} On by
-  default; Tugboat automatically creates a Preview when a GitLab merge request
-  is opened.
-- {{% ui-text %}}Rebuild updated Merge Requests automatically{{% /ui-text %}} On
-  by default; Tugboat automatically creates a Preview when the corresponding
-  merge request is updated.
-- {{% ui-text %}}Delete Merge Request Previews automatically{{% /ui-text %}} On
-  by default; Tugboat automatically deletes a Preview when its merge request is
-  merged or closed.
-- {{% ui-text %}}Set Merge Request build status{{% /ui-text %}} On by default;
-  Tugboat updates the merge request build status to reflect the state of its
-  Preview.
-- {{% ui-text %}}Post Preview links in Merge Request comments{{% /ui-text %}} Off by default; Tugboat adds a comment to a merge request with links to its
-  Preview. The comment author is the person who authenticated the git repo to
-  Tugboat; to change this, see:
+- {{% ui-text %}}Build Merge Requests automatically{{% /ui-text %}} On by default; Tugboat automatically creates a
+  Preview when a GitLab merge request is opened.
+- {{% ui-text %}}Rebuild updated Merge Requests automatically{{% /ui-text %}} On by default; Tugboat automatically
+  creates a Preview when the corresponding merge request is updated.
+- {{% ui-text %}}Delete Merge Request Previews automatically{{% /ui-text %}} On by default; Tugboat automatically
+  deletes a Preview when its merge request is merged or closed.
+- {{% ui-text %}}Set Merge Request build status{{% /ui-text %}} On by default; Tugboat updates the merge request build
+  status to reflect the state of its Preview.
+- {{% ui-text %}}Post Preview links in Merge Request comments{{% /ui-text %}} Off by default; Tugboat adds a comment to
+  a merge request with links to its Preview. The comment author is the person who authenticated the git repo to Tugboat;
+  to change this, see:
   [Add a Tugboat Bot to your team](../../administer-tugboat-crew/user-admin/#add-a-tugboat-bot-to-your-team).
-- {{% ui-text %}}Build Previews for forked Merge Requests{{% /ui-text %}} Off by
-  default; Tugboat builds Previews for merge requests made to the primary repo
-  from forked repositories. **There are security implications from using this
-  setting:** any secrets in your Preview will be accessible by the owner of the
-  forked repository. When this feature is not enabled, forked merge requests
-  show as available to build (or will attempt to build automatically if you have
-  {{% ui-text %}}Build Merge Requests Automatically{{% /ui-text %}} enabled) but
-  the Preview build will fail.
+- {{% ui-text %}}Build Previews for forked Merge Requests{{% /ui-text %}} Off by default; Tugboat builds Previews for
+  merge requests made to the primary repo from forked repositories. **There are security implications from using this
+  setting:** any secrets in your Preview will be accessible by the owner of the forked repository. When this feature is
+  not enabled, forked merge requests show as available to build (or will attempt to build automatically if you have
+  {{% ui-text %}}Build Merge Requests Automatically{{% /ui-text %}} enabled) but the Preview build will fail.
 
-You can also specify the account from which comments are posted to GitLab in
-this section. For info on customizing this, see:
-[Add a Tugboat Bot to your team](../../administer-tugboat-crew/user-admin/#add-a-tugboat-bot-to-your-team).
+You can also specify the account from which comments are posted to GitLab in this section. For info on customizing this,
+see: [Add a Tugboat Bot to your team](../../administer-tugboat-crew/user-admin/#add-a-tugboat-bot-to-your-team).
 
 ## Bitbucket
 
@@ -190,74 +171,58 @@ Once you complete Bitbucket authorization, you'll be redirected to the
 
 ### Using the Bitbucket integration
 
-The BitBucket integration gives Tugboat the following features, which you can
-access in your Project -> Repository Settings:
+The BitBucket integration gives Tugboat the following features, which you can access in your Project -> Repository
+Settings:
 
-- {{% ui-text %}}Build Pull Requests automatically{{% /ui-text %}} On by
-  default; Tugboat automatically creates a Preview when a Bitbucket pull request
-  is opened.
-- {{% ui-text %}}Rebuild updated Pull Requests automatically{{% /ui-text %}} On
-  by default; Tugboat automatically rebuilds a Preview when the corresponding
-  pull request is updated.
-- {{% ui-text %}}Delete Pull Request Previews automatically{{% /ui-text %}} On
-  by default; Tugboat automatically deletes a Preview when its pull request is
-  merged or closed.
-- {{% ui-text %}}Set Pull Request status{{% /ui-text %}} On by default; Tugboat
-  updates the pull request status to reflect the state of its Preview.
-- {{% ui-text %}}Post Preview links in Pull Request comments{{% /ui-text %}} Off
-  by default; Tugboat adds a comment to a pull request with links to its
-  Preview. The comment author is the person who authenticated the git repo to
-  Tugboat; to change this, see:
+- {{% ui-text %}}Build Pull Requests automatically{{% /ui-text %}} On by default; Tugboat automatically creates a
+  Preview when a Bitbucket pull request is opened.
+- {{% ui-text %}}Rebuild updated Pull Requests automatically{{% /ui-text %}} On by default; Tugboat automatically
+  rebuilds a Preview when the corresponding pull request is updated.
+- {{% ui-text %}}Delete Pull Request Previews automatically{{% /ui-text %}} On by default; Tugboat automatically deletes
+  a Preview when its pull request is merged or closed.
+- {{% ui-text %}}Set Pull Request status{{% /ui-text %}} On by default; Tugboat updates the pull request status to
+  reflect the state of its Preview.
+- {{% ui-text %}}Post Preview links in Pull Request comments{{% /ui-text %}} Off by default; Tugboat adds a comment to a
+  pull request with links to its Preview. The comment author is the person who authenticated the git repo to Tugboat; to
+  change this, see:
   [Add a Tugboat Bot to your team](../../administer-tugboat-crew/user-admin/#add-a-tugboat-bot-to-your-team).
-- {{% ui-text %}}Build Previews for forked Pull Requests{{% /ui-text %}} Off by
-  default; Tugboat builds Previews for pull requests made to the primary repo
-  from forked repositories. **There are security implications from using this
-  setting:** any secrets in your Preview will be accessible by the owner of the
-  forked repository. When this feature is not enabled, forked pull requests show
-  as available to build (or will attempt to build automatically if you have
-  {{% ui-text %}}Build Pull Requests Automatically{{% /ui-text %}} enabled) but
-  the Preview build will fail.
+- {{% ui-text %}}Build Previews for forked Pull Requests{{% /ui-text %}} Off by default; Tugboat builds Previews for
+  pull requests made to the primary repo from forked repositories. **There are security implications from using this
+  setting:** any secrets in your Preview will be accessible by the owner of the forked repository. When this feature is
+  not enabled, forked pull requests show as available to build (or will attempt to build automatically if you have
+  {{% ui-text %}}Build Pull Requests Automatically{{% /ui-text %}} enabled) but the Preview build will fail.
 
-You can also specify the account from which comments are posted to Bitbucket in
-this section. For info on customizing this, see:
-[Add a Tugboat Bot to your team](../../administer-tugboat-crew/user-admin/#add-a-tugboat-bot-to-your-team).
+You can also specify the account from which comments are posted to Bitbucket in this section. For info on customizing
+this, see: [Add a Tugboat Bot to your team](../../administer-tugboat-crew/user-admin/#add-a-tugboat-bot-to-your-team).
 
 ## Generic Git Server
 
-If you're not using GitHub, GitLab, or Bitbucket, you can use a generic git
-server with Tugboat. You'll [sign in to Tugboat](https://dashboard.tugboat.qa/)
-using an email address, and when you go to add a repo to your Tugboat project,
-you can link to a Git URL.
+If you're not using GitHub, GitLab, or Bitbucket, you can use a generic git server with Tugboat. You'll
+[sign in to Tugboat](https://dashboard.tugboat.qa/) using an email address, and when you go to add a repo to your
+Tugboat project, you can link to a Git URL.
 
-{{% notice warning %}} If your repo isn't connected via Tugboat's GitHub,
-GitLab, or Bitbucket authentication, you won't have the integration features to
-automatically build Previews from Pull Requests, and other related
-functionality. If you add GitHub, GitLab, or Bitbucket authentication later,
-you'll need to delete your generic git server from your project, and add it
-again to use it. {{% /notice %}}
+{{% notice warning %}} If your repo isn't connected via Tugboat's GitHub, GitLab, or Bitbucket authentication, you won't
+have the integration features to automatically build Previews from Pull Requests, and other related functionality. If
+you add GitHub, GitLab, or Bitbucket authentication later, you'll need to delete your generic git server from your
+project, and add it again to use it. {{% /notice %}}
 
 ## Adding a link to a git provider
 
-Need to add a git provider to your Tugboat account? Whether you created your
-initial Tugboat account with an email and now want to add a git provider, or
-whether you're adding your second or third git provider, here's how to connect
-your Tugboat account with additional git providers:
+Need to add a git provider to your Tugboat account? Whether you created your initial Tugboat account with an email and
+now want to add a git provider, or whether you're adding your second or third git provider, here's how to connect your
+Tugboat account with additional git providers:
 
-1. Click the {{% ui-text %}}User{{% /ui-text %}} drop-down in the upper
-   right-hand corner of the Tugboat dashboard, and select
-   {{% ui-text %}}Profile{{% /ui-text %}}.
+1. Click the {{% ui-text %}}User{{% /ui-text %}} drop-down in the upper right-hand corner of the Tugboat dashboard, and
+   select {{% ui-text %}}Profile{{% /ui-text %}}.
 2. Click the {{% ui-text %}}+ Connect Account{{% /ui-text %}} link.
 3. Select the git provider whose account you'd like to connect.
-4. Follow the instructions to connect to
-   [GitHub](#how-do-i-link-tugboat-to-github),
-   [GitLab](#how-do-i-link-tugboat-to-gitlab) or
-   [Bitbucket](#how-do-i-link-tugboat-to-bitbucket).
+4. Follow the instructions to connect to [GitHub](#how-do-i-link-tugboat-to-github),
+   [GitLab](#how-do-i-link-tugboat-to-gitlab) or [Bitbucket](#how-do-i-link-tugboat-to-bitbucket).
 
 {{%expand "Visual Walkthrough" %}}
 
-Click the {{% ui-text %}}User{{% /ui-text %}} drop-down in the upper right-hand
-corner of the Tugboat dashboard, and select
-{{% ui-text %}}Profile{{% /ui-text %}}.
+Click the {{% ui-text %}}User{{% /ui-text %}} drop-down in the upper right-hand corner of the Tugboat dashboard, and
+select {{% ui-text %}}Profile{{% /ui-text %}}.
 
 ![Go to User drop-down, and select Profile](../../_images/go-to-user-select-profile.png)
 
@@ -270,7 +235,6 @@ Select the git provider whose account you'd like to connect.
 ![Select a git provider](../../_images/add-accounts-select-a-git-provider.png)
 
 Follow the instructions to connect to  
- [GitHub](#how-do-i-link-tugboat-to-github), [GitLab](#how-do-i-link-tugboat-to-gitlab)
-or [Bitbucket](#how-do-i-link-tugboat-to-bitbucket).
+ [GitHub](#how-do-i-link-tugboat-to-github), [GitLab](#how-do-i-link-tugboat-to-gitlab) or [Bitbucket](#how-do-i-link-tugboat-to-bitbucket).
 
 {{% /expand%}}

--- a/content/setting-up-tugboat/create-a-new-project.md
+++ b/content/setting-up-tugboat/create-a-new-project.md
@@ -4,22 +4,19 @@ date: 2019-09-17T11:41:50-04:00
 weight: 2
 ---
 
-Once you've connected Tugboat to your preferred git provider, it's time to
-create a new project!
+Once you've connected Tugboat to your preferred git provider, it's time to create a new project!
 
 - [How to create a project](#how-to-create-a-project)
 - [Things to know about Tugboat projects](#things-to-know-about-tugboat-projects)
 
-Once you hit the {{% ui-text %}}Create Project{{% /ui-text %}} button, it's
-anchors away!
+Once you hit the {{% ui-text %}}Create Project{{% /ui-text %}} button, it's anchors away!
 
 ## How to create a project
 
-The first time you sign into Tugboat, you'll go directly to the Create New
-Project screen.
+The first time you sign into Tugboat, you'll go directly to the Create New Project screen.
 
-After you've already got a project, you can add more by going to the Tugboat
-Dashboard and selecting {{% ui-text %}}Create New Project{{% /ui-text %}}.
+After you've already got a project, you can add more by going to the Tugboat Dashboard and selecting
+{{% ui-text %}}Create New Project{{% /ui-text %}}.
 
 ![Select the Create New Project link](../../_images/create-a-new-project.png)
 
@@ -28,19 +25,14 @@ Dashboard and selecting {{% ui-text %}}Create New Project{{% /ui-text %}}.
 When you're creating a project, there are a few things to keep in mind:
 
 - A Tugboat project is a collection of any number of repos across git providers
-- Tugboat's pricing tiers and billing are specified on the project level, not
-  based on the number of repositories
+- Tugboat's pricing tiers and billing are specified on the project level, not based on the number of repositories
 - Users are managed on a per project basis
 
-Deciding which users need to be able to access which projects can help you
-figure out how you want to organize, too. For example, let's say you are
-building a recipe site that consists of a backend Drupal repository and a
-frontend React repository. If the entire development team should have access to
-both repositories within Tugboat, you should probably create a single project
-for both repositories in Tugboat.
+Deciding which users need to be able to access which projects can help you figure out how you want to organize, too. For
+example, let's say you are building a recipe site that consists of a backend Drupal repository and a frontend React
+repository. If the entire development team should have access to both repositories within Tugboat, you should probably
+create a single project for both repositories in Tugboat.
 
-On the other hand, let's say you have a WordPress blog that is managed by an
-outside vendor. Also, you have a separate and unrelated Node.js application that
-is a "top secret" internal project your company is working on. It may be best to
-create two separate projects so that you can manage permissions for each of the
-projects independently.
+On the other hand, let's say you have a WordPress blog that is managed by an outside vendor. Also, you have a separate
+and unrelated Node.js application that is a "top secret" internal project your company is working on. It may be best to
+create two separate projects so that you can manage permissions for each of the projects independently.

--- a/content/setting-up-tugboat/create-a-tugboat-config-file.md
+++ b/content/setting-up-tugboat/create-a-tugboat-config-file.md
@@ -4,21 +4,19 @@ date: 2019-09-17T11:42:29-04:00
 weight: 5
 ---
 
-The final step in setting up your Tugboat is committing a YAML Config file in
-the source's git repository. Think of the Config file as the engine that powers
-Tugboat; here's where you specify the Services you want to run when your Tugboat
+The final step in setting up your Tugboat is committing a YAML Config file in the source's git repository. Think of the
+Config file as the engine that powers Tugboat; here's where you specify the Services you want to run when your Tugboat
 Preview builds.
 
-The Tugboat Config file should live at: `.tugboat/config.yml` in the branch,
-tag, commit or pull request that is being built.
+The Tugboat Config file should live at: `.tugboat/config.yml` in the branch, tag, commit or pull request that is being
+built.
 
-Creating the Config file can be a complex process, like building a Tugboat's
-engine from parts! These docs can help get you started:
+Creating the Config file can be a complex process, like building a Tugboat's engine from parts! These docs can help get
+you started:
 
 - [Setting up Services in your Tugboat](/setting-up-services/)
-- [Starter Configuration files](/starter-configs/) (configuration file code
-  snippets with comments to help you get started)
+- [Starter Configuration files](/starter-configs/) (configuration file code snippets with comments to help you get
+  started)
 - [Using the Tugboat Command Line Tool](/tugboat-cli/)
-- [Tugboat Configuration](/reference/tugboat-configuration/) (detailing the
-  attributes you can use when building
+- [Tugboat Configuration](/reference/tugboat-configuration/) (detailing the attributes you can use when building
 - [Debugging Config files](/troubleshooting/debug-config-file/)

--- a/content/setting-up-tugboat/select-repo-settings.md
+++ b/content/setting-up-tugboat/select-repo-settings.md
@@ -4,8 +4,8 @@ date: 2019-09-17T11:42:15-04:00
 weight: 4
 ---
 
-After you've created a project, you might want to go in and tweak your Tugboat
-repo settings. When you go into Repository Settings, you can:
+After you've created a project, you might want to go in and tweak your Tugboat repo settings. When you go into
+Repository Settings, you can:
 
 - [Modify settings for your GitHub, GitLab, or Bitbucket integration](#modify-settings-for-your-github-gitlab-or-bitbucket-integration)
 - [Rebuild Orphaned Previews Automatically](#rebuild-orphaned-previews-automatically)
@@ -17,150 +17,123 @@ repo settings. When you go into Repository Settings, you can:
 - [Authenticate with a Docker Registry](#authenticate-with-a-docker-registry)
 - [Delete the repo](#delete-the-repository)
 
-Don't forget to hit the {{% ui-text %}}Save Configuration{{% /ui-text %}} button
-after you've checked or unchecked boxes to save your changes.
+Don't forget to hit the {{% ui-text %}}Save Configuration{{% /ui-text %}} button after you've checked or unchecked boxes
+to save your changes.
 
 If you later need to change Repository Settings, you can do that anytime; see:
 [Change Repository Settings](#change-repository-settings).
 
 ### Modify settings for your GitHub, GitLab or Bitbucket Integration
 
-When you're using the Tugboat integration with GitHub, GitLab or Bitbucket,
-you'll see provider-specific settings for each of your Tugboat repos. These
-settings enable you to do things like automatically create a Preview when a Pull
-Request or Merge Request is opened, or post a comment to a PR with links to its
-Preview. For a full list of the provider-specific integration options, check
-out:
+When you're using the Tugboat integration with GitHub, GitLab or Bitbucket, you'll see provider-specific settings for
+each of your Tugboat repos. These settings enable you to do things like automatically create a Preview when a Pull
+Request or Merge Request is opened, or post a comment to a PR with links to its Preview. For a full list of the
+provider-specific integration options, check out:
 
 - [Using the GitHub integration](../connect-with-your-provider/#using-the-github-integration)
 - [Using the GitLab integration](../connect-with-your-provider/#using-the-gitlab-integration)
 - [Using the BitBucket integration](../connect-with-your-provider/#using-the-bitbucket-integration)
 
-{{% notice info %}} Want to create a generic user to post comments to your
-linked git provider? Take a look at
-[Add a Tugboat bot to your team](/administer-tugboat-crew/add-tugboat-bot-to-team/)
-for details. {{% /notice %}}
+{{% notice info %}} Want to create a generic user to post comments to your linked git provider? Take a look at
+[Add a Tugboat bot to your team](/administer-tugboat-crew/add-tugboat-bot-to-team/) for details. {{% /notice %}}
 
 ### Rebuild Orphaned Previews Automatically
 
 When this option is selected, Tugboat automatically
 [rebuilds Previews](/building-a-preview/automate-previews/auto-update/) when the
-[Base Preview](/building-a-preview/work-with-base-previews/set-a-base-preview/)
-they're built from is
-[rebuilt](/building-a-preview/work-with-base-previews/change-or-update/). This
-option is turned off by default.
+[Base Preview](/building-a-preview/work-with-base-previews/set-a-base-preview/) they're built from is
+[rebuilt](/building-a-preview/work-with-base-previews/change-or-update/). This option is turned off by default.
 
 ### Rebuild Stale Previews Automatically
 
 When this option is selected, Tugboat automatically
 [rebuilds Previews](/building-a-preview/automate-previews/auto-update/) when the
-[Base Preview](/building-a-preview/work-with-base-previews/set-a-base-preview/)
-they're built from is
-[refreshed](/building-a-preview/work-with-base-previews/change-or-update/#update-a-base-preview).
-This option is turned off by default.
+[Base Preview](/building-a-preview/work-with-base-previews/set-a-base-preview/) they're built from is
+[refreshed](/building-a-preview/work-with-base-previews/change-or-update/#update-a-base-preview). This option is turned
+off by default.
 
 To unpack this a little:
 
-- When you're using a
-  [Base Preview](/building-a-preview/work-with-base-previews/set-a-base-preview)
+- When you're using a [Base Preview](/building-a-preview/work-with-base-previews/set-a-base-preview)
 - And the Base Preview is
   [refreshed](/building-a-preview/work-with-base-previews/change-or-update/#update-a-base-preview)  
   (You may manually Refresh a Base Preview, or have Tugboat
-  [refresh Base Previews automatically](#refresh-base-previews-automatically),
-  for example, every day at 12am UTC.)
+  [refresh Base Previews automatically](#refresh-base-previews-automatically), for example, every day at 12am UTC.)
 - The Base Preview kicks off the
-  [build process](/building-a-preview/preview-deep-dive/how-previews-work/#the-build-process-explained)
-  from the `update` phase, and runs commands in both `update` and `build`
-- When the Base Preview refresh is complete, child Previews kick off a build
-  process from `build`, using the Base Preview as the starting point and
-  bypassing commands in `init` and `update`.
+  [build process](/building-a-preview/preview-deep-dive/how-previews-work/#the-build-process-explained) from the
+  `update` phase, and runs commands in both `update` and `build`
+- When the Base Preview refresh is complete, child Previews kick off a build process from `build`, using the Base
+  Preview as the starting point and bypassing commands in `init` and `update`.
 
 ### Refresh Base Previews Automatically
 
-By default, Tugboat refreshes your Base Previews every day at 12am UTC. You can
-de-select this checkbox to turn off automatic refresh, or you can specify your
-preferred interval and time for the refresh to occur. Automatically refreshing
-Base Previews is a great way to ensure your large assets, such as databases,
-stay up-to-date, saving you time when you build a new Preview from a
-recently-refreshed Base Preview.
+By default, Tugboat refreshes your Base Previews every day at 12am UTC. You can de-select this checkbox to turn off
+automatic refresh, or you can specify your preferred interval and time for the refresh to occur. Automatically
+refreshing Base Previews is a great way to ensure your large assets, such as databases, stay up-to-date, saving you time
+when you build a new Preview from a recently-refreshed Base Preview.
 
 ### Specify Build Timeout
 
-By default, Preview builds timeout at 3600 seconds. You can change the Preview
-build timeout to your preferred interval.
+By default, Preview builds timeout at 3600 seconds. You can change the Preview build timeout to your preferred interval.
 
 ### Modify Environment Variables
 
-Here's where you can enter environment variables, like API keys or passwords,
-that you wouldn't want to store in your repo. If you're looking for Tugboat's
-environment variables to add to your Build Scripts or configuration files, check
+Here's where you can enter environment variables, like API keys or passwords, that you wouldn't want to store in your
+repo. If you're looking for Tugboat's environment variables to add to your Build Scripts or configuration files, check
 out [Reference -> Environment Variables](/reference/environment-variables).
 
 ### Set up Remote SSH Access
 
-SSH commands that you run from Previews in this repository use the public key in
-your repo settings. Each of your repositories linked to Tugboat have a unique
-SSH key. Put this public key on the remote servers that your build scripts or
-applications need to access.
+SSH commands that you run from Previews in this repository use the public key in your repo settings. Each of your
+repositories linked to Tugboat have a unique SSH key. Put this public key on the remote servers that your build scripts
+or applications need to access.
 
 - [Use the Tugboat SSH key](#use-the-tugboat-ssh-key)
 - [Delete an SSH key](#delete-an-ssh-key)
 
-{{% notice info %}} You can't SSH into a Tugboat Preview; the SSH key here is
-all about outbound requests to remote resources. If you want to get _into_ a
-Tugboat Preview, shell access is provided in both the web interface and the
+{{% notice info %}} You can't SSH into a Tugboat Preview; the SSH key here is all about outbound requests to remote
+resources. If you want to get _into_ a Tugboat Preview, shell access is provided in both the web interface and the
 [command line tool](/tugboat-cli/). {{% /notice %}}
 
 #### Use the Tugboat SSH key
 
-When you link a git repository to Tugboat, Tugboat automatically generates an
-SSH key for that repo. You can access this key in
-[Repository Settings](#change-repository-settings); scroll to the
-{{% ui-text %}}Remote SSH Access{{% /ui-text %}} option. To use the SSH key,
-simply copy it to your clipboard and put it where you need it!
+When you link a git repository to Tugboat, Tugboat automatically generates an SSH key for that repo. You can access this
+key in [Repository Settings](#change-repository-settings); scroll to the {{% ui-text %}}Remote SSH
+Access{{% /ui-text %}} option. To use the SSH key, simply copy it to your clipboard and put it where you need it!
 
 ![Copy SSH Key to Clipboard](../../_images/remote-ssh-access-copy-ssh-key.png)
 
-{{% notice info %}} Tugboat provides a private 4096 bit length RSA SSH key. What
-you see on the Repository Settings page is the public key from the pair.
-{{% /notice %}}
+{{% notice info %}} Tugboat provides a private 4096 bit length RSA SSH key. What you see on the Repository Settings page
+is the public key from the pair. {{% /notice %}}
 
-If you want Tugboat to generate a new SSH key, press the {{% ui-text %}}Generate
-SSH Key{{% /ui-text %}} button. You'll see a dialog box asking you to confirm
-that you want to generate a new key, as this action can't be undone.
+If you want Tugboat to generate a new SSH key, press the {{% ui-text %}}Generate SSH Key{{% /ui-text %}} button. You'll
+see a dialog box asking you to confirm that you want to generate a new key, as this action can't be undone.
 
-{{% notice warning %}} If you have Tugboat create a new SSH key, this
-automatically erases the existing SSH key. If you're using this SSH key
-anywhere, you'll need to update that when you generate a new key.
-{{% /notice %}}
+{{% notice warning %}} If you have Tugboat create a new SSH key, this automatically erases the existing SSH key. If
+you're using this SSH key anywhere, you'll need to update that when you generate a new key. {{% /notice %}}
 
 #### Delete an SSH key
 
-Need to delete or get rid of an SSH key? Go to
-[Repository Settings](#change-repository-settings); scroll to the
-{{% ui-text %}}Remote SSH Access{{% /ui-text %}} option for the repository whose
-key you want to delete, and press the {{% ui-text %}}Generate SSH
-Key{{% /ui-text %}} button. Generating a new key permanently erases the old key.
+Need to delete or get rid of an SSH key? Go to [Repository Settings](#change-repository-settings); scroll to the
+{{% ui-text %}}Remote SSH Access{{% /ui-text %}} option for the repository whose key you want to delete, and press the
+{{% ui-text %}}Generate SSH Key{{% /ui-text %}} button. Generating a new key permanently erases the old key.
 
 ### Authenticate with a Docker Registry
 
-If you want to pull images from Docker registries that require authentication,
-you can manage your authorization credentials from within the repo settings.
+If you want to pull images from Docker registries that require authentication, you can manage your authorization
+credentials from within the repo settings.
 
 ![Authenticate with a Docker registry](../../_images/authenticate-with-a-docker-registry-add-credentials.png)
 
 ### Delete the Repository
 
-If you want to delete a repo from your Tugboat project, you'll go into the
-Repository Settings for that repo and press the {{% ui-text %}}Delete
-Repository{{% /ui-text %}} button. Deleting a repo from Tugboat does not affect
-any data in the git provider repo connected to it, nor does it delete the
-Tugboat project that contains the repo.
+If you want to delete a repo from your Tugboat project, you'll go into the Repository Settings for that repo and press
+the {{% ui-text %}}Delete Repository{{% /ui-text %}} button. Deleting a repo from Tugboat does not affect any data in
+the git provider repo connected to it, nor does it delete the Tugboat project that contains the repo.
 
 ![Delete repository](../../_images/delete-repository.png)
 
-{{% notice note %}} Only Admin users have the **Delete Repository** option. For
-more on user permissions, see:
+{{% notice note %}} Only Admin users have the **Delete Repository** option. For more on user permissions, see:
 [User permission levels explained](/administer-tugboat-crew/user-admin/#user-permission-levels-explained).
 {{% /notice %}}
 
@@ -168,12 +141,10 @@ more on user permissions, see:
 
 Any time you need to make a change to Repository Settings:
 
-1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-   upper-right of the Tugboat screen.
+1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat screen.
 2. Select the project where you want to edit repository settings.
-3. Scroll to the linked repository whose settings you want to change, and click
-   the {{% ui-text %}}Settings{{% /ui-text %}} link.
+3. Scroll to the linked repository whose settings you want to change, and click the
+   {{% ui-text %}}Settings{{% /ui-text %}} link.
 
-From here, you'll see all the Repository Settings you can modify. If you make
-changes to the settings, don't forget to press the {{% ui-text %}}Save
-Configuration{{% /ui-text %}} button!
+From here, you'll see all the Repository Settings you can modify. If you make changes to the settings, don't forget to
+press the {{% ui-text %}}Save Configuration{{% /ui-text %}} button!

--- a/content/starter-configs/_index.md
+++ b/content/starter-configs/_index.md
@@ -14,8 +14,6 @@ Starter configuration files and code snippets to kick-start your Tugboat build.
 
 {{% children depth="4" %}}
 
-In addition to these code snippets and tutorials, we also maintain repositories
-with
-[starter configuration files](https://github.com/search?q=topic%3Astarter-kit+org%3ATugboatQA&type=Repositories)
-for other frameworks and Content Management Systems in our
-[GitHub account](https://github.com/TugboatQA).
+In addition to these code snippets and tutorials, we also maintain repositories with
+[starter configuration files](https://github.com/search?q=topic%3Astarter-kit+org%3ATugboatQA&type=Repositories) for
+other frameworks and Content Management Systems in our [GitHub account](https://github.com/TugboatQA).

--- a/content/starter-configs/code-snippets/functional-tests.md
+++ b/content/starter-configs/code-snippets/functional-tests.md
@@ -4,8 +4,7 @@ date: 2019-09-19T10:59:31-04:00
 weight: 5
 ---
 
-Here is an example of how you might use Tugboat to run functional tests; add a
-snippet like this to your
+Here is an example of how you might use Tugboat to run functional tests; add a snippet like this to your
 [configuration file](/setting-up-tugboat/create-a-tugboat-config-file/).
 
 In this case, the tests are run with CasperJS.

--- a/content/starter-configs/code-snippets/generic-lamp.md
+++ b/content/starter-configs/code-snippets/generic-lamp.md
@@ -4,15 +4,14 @@ date: 2019-09-19T10:59:39-04:00
 weight: 2
 ---
 
-A Generic LAMP stack should work with most PHP/MySQL web applications. You may
-need to do some customizing, but this should get you started.
+A Generic LAMP stack should work with most PHP/MySQL web applications. You may need to do some customizing, but this
+should get you started.
 
 ## Configure Tugboat
 
-The Tugboat configuration is managed by a
-[YAML file](/setting-up-tugboat/create-a-tugboat-config-file/) at
-`.tugboat/config.yml` in the git repository. Here's a basic LAMP configuration
-you can use as a starting point, with comments to explain what's going on:
+The Tugboat configuration is managed by a [YAML file](/setting-up-tugboat/create-a-tugboat-config-file/) at
+`.tugboat/config.yml` in the git repository. Here's a basic LAMP configuration you can use as a starting point, with
+comments to explain what's going on:
 
 ```yaml
 services:
@@ -57,8 +56,7 @@ services:
         - rm /tmp/database.sql.gz
 ```
 
-Want to know more about something mentioned in the comments of this config file?
-Check out these topics:
+Want to know more about something mentioned in the comments of this config file? Check out these topics:
 
 - [Name your Service](/setting-up-services/how-to-set-up-services/name-your-service/)
 - [Specify a Service image](/setting-up-services/how-to-set-up-services/specify-a-service-image/)
@@ -71,6 +69,5 @@ Check out these topics:
 
 ## Start Building Previews!
 
-Once this Tugboat configuration file is committed to your git repository, you
-can start
+Once this Tugboat configuration file is committed to your git repository, you can start
 [building previews](/building-a-preview/administer-previews/build-previews/)!

--- a/content/starter-configs/code-snippets/import-mysql-database.md
+++ b/content/starter-configs/code-snippets/import-mysql-database.md
@@ -6,13 +6,11 @@ weight: 3
 
 This example assumes that there is a mysqldump file available somewhere via SSH.
 
-First, import the Tugboat Repository's
-[SSH key](/setting-up-tugboat/select-repo-settings/#set-up-remote-ssh-access) to
+First, import the Tugboat Repository's [SSH key](/setting-up-tugboat/select-repo-settings/#set-up-remote-ssh-access) to
 the server hosting the file.
 
-Then, use this snippet in your
-[configuration file](/setting-up-tugboat/create-a-tugboat-config-file/) to
-import the database into a [service](/setting-up-services/) named "mysql".
+Then, use this snippet in your [configuration file](/setting-up-tugboat/create-a-tugboat-config-file/) to import the
+database into a [service](/setting-up-services/) named "mysql".
 
 ```yaml
 services:

--- a/content/starter-configs/code-snippets/page-cache.md
+++ b/content/starter-configs/code-snippets/page-cache.md
@@ -4,10 +4,8 @@ date: 2019-09-19T11:00:02-04:00
 weight: 7
 ---
 
-If your web application has a page caching layer, you can prime the cache from
-within the
-[Tugboat config file](/setting-up-tugboat/create-a-tugboat-config-file/). This
-code snippet should get you started:
+If your web application has a page caching layer, you can prime the cache from within the
+[Tugboat config file](/setting-up-tugboat/create-a-tugboat-config-file/). This code snippet should get you started:
 
 ```services:
   php:
@@ -17,6 +15,5 @@ code snippet should get you started:
         - "wget -e robots=off --quiet --page-requisites --delete-after --header \"Host: tugboat.qa\" http://localhost || /bin/true"
 ```
 
-Calling `localhost` will cause Tugboat to load the front page of your
-application. `page-requisites` loads all images, and `delete-after` removes the
-downloaded assets to preserve disk space.
+Calling `localhost` will cause Tugboat to load the front page of your application. `page-requisites` loads all images,
+and `delete-after` removes the downloaded assets to preserve disk space.

--- a/content/starter-configs/code-snippets/phpmyadmin.md
+++ b/content/starter-configs/code-snippets/phpmyadmin.md
@@ -4,22 +4,17 @@ date: 2019-09-19T11:00:19-04:00
 weight: 4
 ---
 
-Database management tools such as MySQL Workbench or Sequel Pro are commonly
-used by developers to work with a MySQL database. However, Tugboat does not
-provide a way for these tools to connect to a database in a Preview. A popular
-alternative is to use [phpMyAdmin](https://www.phpmyadmin.net/) to fill this
-gap.
+Database management tools such as MySQL Workbench or Sequel Pro are commonly used by developers to work with a MySQL
+database. However, Tugboat does not provide a way for these tools to connect to a database in a Preview. A popular
+alternative is to use [phpMyAdmin](https://www.phpmyadmin.net/) to fill this gap.
 
-{{% notice warning %}} Exposing a phpMyAdmin service grants full access to the
-database for the Tugboat Preview to anyone who has the link. While it is best
-practice to avoid storing sensitive data in Tugboat, it is still a good idea to
-be careful about sharing this link. {{% /notice %}}
+{{% notice warning %}} Exposing a phpMyAdmin service grants full access to the database for the Tugboat Preview to
+anyone who has the link. While it is best practice to avoid storing sensitive data in Tugboat, it is still a good idea
+to be careful about sharing this link. {{% /notice %}}
 
-You can use the official phpMyAdmin
-[Docker image](https://hub.docker.com/r/phpmyadmin/phpmyadmin) can with Tugboat.
-Here is an example
-[config file](/setting-up-tugboat/create-a-tugboat-config-file/) showing how you
-might add a phpmyadmin service to a Tugboat Preview:
+You can use the official phpMyAdmin [Docker image](https://hub.docker.com/r/phpmyadmin/phpmyadmin) can with Tugboat.
+Here is an example [config file](/setting-up-tugboat/create-a-tugboat-config-file/) showing how you might add a
+phpmyadmin service to a Tugboat Preview:
 
 ```yaml
 services:
@@ -30,39 +25,32 @@ services:
     image: phpmyadmin/phpmyadmin
 ```
 
-{{% notice tip %}} MySQL 8 uses a new authentication method, which does not work
-with the PHP mysqli extension that phpMyAdmin uses. To work around this, alter
-the "tugboat" MySQL user with an init command for the `mysql` service. Your
+{{% notice tip %}} MySQL 8 uses a new authentication method, which does not work with the PHP mysqli extension that
+phpMyAdmin uses. To work around this, alter the "tugboat" MySQL user with an init command for the `mysql` service. Your
 config.yml might look like this: {{% /notice %}}
 
 ```yaml
 mysql:
   image: tugboatqa/mysql:8
   commands:
-    init:
-      mysql -e "ALTER USER 'tugboat'@'%' IDENTIFIED WITH mysql_native_password
-      BY 'tugboat';"
+    init: mysql -e "ALTER USER 'tugboat'@'%' IDENTIFIED WITH mysql_native_password BY 'tugboat';"
 ```
 
-Once you've added the phpmyadmin service to your Tugboat config, you will need
-to follow the instructions on the
-[Custom Environment Variables](/setting-up-services/how-to-set-up-services/custom-environment-variables/)
-to add the following environment variables to your Repository Settings:
+Once you've added the phpmyadmin service to your Tugboat config, you will need to follow the instructions on the
+[Custom Environment Variables](/setting-up-services/how-to-set-up-services/custom-environment-variables/) to add the
+following environment variables to your Repository Settings:
 
-- **`PMA_HOST`** - Set this to the name of the MySQL service that you would like
-  phpmyadmin to connect to. In the example yml config above, the service name is
-  `mysql`
+- **`PMA_HOST`** - Set this to the name of the MySQL service that you would like phpmyadmin to connect to. In the
+  example yml config above, the service name is `mysql`
 
-- **`PMA_USER`** - Set this environment variable to a MySQL user that can
-  connect to the above MySQL service. Typically this is the default `tugboat`
-  user
+- **`PMA_USER`** - Set this environment variable to a MySQL user that can connect to the above MySQL service. Typically
+  this is the default `tugboat` user
 
-- **`PMA_PASSWORD`** - This is the password for the above MySQL user. The
-  default password for the `tugboat` user is also `tugboat`
+- **`PMA_PASSWORD`** - This is the password for the above MySQL user. The default password for the `tugboat` user is
+  also `tugboat`
 
-Once you've added these environment variables, you're ready to build a new
-Preview with phpMyAdmin. Note that we are exposing port 80 in the config.yml
-above, which will give you a separate {{% ui-text %}}Preview{{% /ui-text %}}
-button on the Tugboat Preview Dashboard for phpMyAdmin:
+Once you've added these environment variables, you're ready to build a new Preview with phpMyAdmin. Note that we are
+exposing port 80 in the config.yml above, which will give you a separate {{% ui-text %}}Preview{{% /ui-text %}} button
+on the Tugboat Preview Dashboard for phpMyAdmin:
 
 ![Click Preview to access phpMyAdmin](/_images/phpmyadmin-preview.png)

--- a/content/starter-configs/code-snippets/simpletest.md
+++ b/content/starter-configs/code-snippets/simpletest.md
@@ -4,9 +4,8 @@ date: 2019-09-19T11:00:28-04:00
 weight: 6
 ---
 
-Here is an example of how you might use Tugboat to run automated testing with
-SimpleTest; simply add a snippet like this to your
-[configuration file](/setting-up-tugboat/create-a-tugboat-config-file/).
+Here is an example of how you might use Tugboat to run automated testing with SimpleTest; simply add a snippet like this
+to your [configuration file](/setting-up-tugboat/create-a-tugboat-config-file/).
 
 ```services:
   php:

--- a/content/starter-configs/code-snippets/static-html.md
+++ b/content/starter-configs/code-snippets/static-html.md
@@ -4,16 +4,13 @@ date: 2019-09-19T11:00:39-04:00
 weight: 1
 ---
 
-A static HTML Tugboat Preview serves files exactly as they are found in the git
-repository.
+A static HTML Tugboat Preview serves files exactly as they are found in the git repository.
 
 ## Configure Tugboat
 
-The Tugboat configuration is managed by a
-[YAML file](/setting-up-tugboat/create-a-tugboat-config-file/) at
-`.tugboat/config.yml` in the git repository. Here's a basic static HTML
-configuration you can use as a starting point, with comments to explain what's
-going on:
+The Tugboat configuration is managed by a [YAML file](/setting-up-tugboat/create-a-tugboat-config-file/) at
+`.tugboat/config.yml` in the git repository. Here's a basic static HTML configuration you can use as a starting point,
+with comments to explain what's going on:
 
 ```yaml
 services:
@@ -36,8 +33,7 @@ services:
         - ln -snf "${TUGBOAT_ROOT}" "${DOCROOT}"
 ```
 
-Want to know more about something mentioned in the comments of this config file?
-Check out these topics:
+Want to know more about something mentioned in the comments of this config file? Check out these topics:
 
 - [Name your Service](/setting-up-services/how-to-set-up-services/name-your-service/)
 - [Specify a Service image](/setting-up-services/how-to-set-up-services/specify-a-service-image/)
@@ -48,6 +44,5 @@ Check out these topics:
 
 ## Start Building Previews!
 
-Once this Tugboat configuration file is committed to your git repository, you
-can start
+Once this Tugboat configuration file is committed to your git repository, you can start
 [building previews](/building-a-preview/administer-previews/build-previews/)!

--- a/content/starter-configs/code-snippets/tenon-io.md
+++ b/content/starter-configs/code-snippets/tenon-io.md
@@ -4,14 +4,12 @@ date: 2019-09-19T11:00:49-04:00
 weight: 8
 ---
 
-[Tenon.io](https://tenon.io) can identify 508 and WCAG 2.0 issues in any
-environment.
+[Tenon.io](https://tenon.io) can identify 508 and WCAG 2.0 issues in any environment.
 
-Before you use this snippet in you own
-[Tugboat config file](/setting-up-tugboat/create-a-tugboat-config-file/),
+Before you use this snippet in you own [Tugboat config file](/setting-up-tugboat/create-a-tugboat-config-file/),
 register for an account on Tenon.io and add your Tenon API Key to Tugboat as a
-[custom environment variable](/setting-up-services/how-to-set-up-services/custom-environment-variables/)
-called `TENON_API`.
+[custom environment variable](/setting-up-services/how-to-set-up-services/custom-environment-variables/) called
+`TENON_API`.
 
 ```yaml
 services:
@@ -26,11 +24,9 @@ services:
       build:
         # Tenon Integration
         - touch results.json
-        - curl -d "url=${TUGBOAT_PREVIEW_URL}&key=${TENON_API}" -H
-          Content-Type:application/x-www-form-urlencoded -H
+        - curl -d "url=${TUGBOAT_PREVIEW_URL}&key=${TENON_API}" -H Content-Type:application/x-www-form-urlencoded -H
           Cache-Control:no-cache -X POST https://tenon.io/api/ > results.json
-        - "jq '{Summary: [.resultSummary .tests], title: .resultSet[]
-          .errorTitle, description: .resultSet[] .errorDescription, snippet:
-          .resultSet[] .errorSnippet, ref: .resultSet[] .ref, resultTitle:
-          .resultSet[] .resultTitle, xpath: .resultSet[] .xpath}' results.json"
+        - "jq '{Summary: [.resultSummary .tests], title: .resultSet[] .errorTitle, description: .resultSet[]
+          .errorDescription, snippet: .resultSet[] .errorSnippet, ref: .resultSet[] .ref, resultTitle: .resultSet[]
+          .resultTitle, xpath: .resultSet[] .xpath}' results.json"
 ```

--- a/content/starter-configs/tutorials/_index.md
+++ b/content/starter-configs/tutorials/_index.md
@@ -10,7 +10,6 @@ pre = ""
 
 # Tutorials
 
-Information about configuring the frameworks, and example config.yml files to
-get you started.
+Information about configuring the frameworks, and example config.yml files to get you started.
 
 {{% children  %}}

--- a/content/starter-configs/tutorials/drupal-7.md
+++ b/content/starter-configs/tutorials/drupal-7.md
@@ -4,19 +4,17 @@ date: 2019-09-19T10:59:15-04:00
 weight: 1
 ---
 
-Wondering how to configure Tugboat for a typical Drupal 7 repository? Every
-Drupal site tends to have slightly different requirements, so you may need to do
-more customizing, but this should get you started.
+Wondering how to configure Tugboat for a typical Drupal 7 repository? Every Drupal site tends to have slightly different
+requirements, so you may need to do more customizing, but this should get you started.
 
 ## Configure Drupal
 
-A common practice for managing Drupal's `settings.php` is to remove sensitive
-information, such as database credentials, before committing it to git. Then,
-the sensitive information is loaded from a `settings.local.php` file that exists
-only on the Drupal installation location.
+A common practice for managing Drupal's `settings.php` is to remove sensitive information, such as database credentials,
+before committing it to git. Then, the sensitive information is loaded from a `settings.local.php` file that exists only
+on the Drupal installation location.
 
-This pattern works very well with Tugboat. It lets you keep a Tugboat-specific
-set of configurations in your repository where it can be copied in during the
+This pattern works very well with Tugboat. It lets you keep a Tugboat-specific set of configurations in your repository
+where it can be copied in during the
 [Preview build process](/building-a-preview/preview-deep-dive/how-previews-work/#the-build-process-explained).
 
 Add the following to the end of `settings.php`:
@@ -27,8 +25,7 @@ if (file_exists(DRUPAL_ROOT . '/' . conf_path() . '/settings.local.php')) {
 }
 ```
 
-Add a file to the git repository at `.tugboat/settings.local.php` with the
-following content:
+Add a file to the git repository at `.tugboat/settings.local.php` with the following content:
 
 ```php
 <?php
@@ -51,11 +48,9 @@ $databases = array (
 
 ## Configure Tugboat
 
-The Tugboat configuration is managed by a
-[YAML file](/setting-up-tugboat/create-a-tugboat-config-file/) at
-`.tugboat/config.yml` in the git repository. Here's a basic Drupal 7
-configuration you can use as a starting point, with comments to explain what's
-going on:
+The Tugboat configuration is managed by a [YAML file](/setting-up-tugboat/create-a-tugboat-config-file/) at
+`.tugboat/config.yml` in the git repository. Here's a basic Drupal 7 configuration you can use as a starting point, with
+comments to explain what's going on:
 
 ```yaml
 services:
@@ -94,14 +89,12 @@ services:
       # already be present.
       update:
         # Use the tugboat-specific Drupal settings
-        - cp "${TUGBOAT_ROOT}/.tugboat/settings.local.php"
-          "${DOCROOT}/sites/default/"
+        - cp "${TUGBOAT_ROOT}/.tugboat/settings.local.php" "${DOCROOT}/sites/default/"
 
         # Copy the files directory from an external server. The public
         # SSH key found in the Tugboat Repository configuration must be
         # copied to the external server in order to use rsync over SSH.
-        - rsync -av --delete user@example.com:/path/to/files/
-          "${DOCROOT}/sites/default/files/"
+        - rsync -av --delete user@example.com:/path/to/files/ "${DOCROOT}/sites/default/files/"
         - chgrp -R www-data "${DOCROOT}/sites/default/files"
         - find "${DOCROOT}/sites/default/files" -type d -exec chmod 2775 {} \;
         - find "${DOCROOT}/sites/default/files" -type f -exec chmod 0664 {} \;
@@ -113,8 +106,7 @@ services:
         # This results in smaller previews and reduces the build time.
         - drush -r "${DOCROOT}" pm-download stage_file_proxy
         - drush -r "${DOCROOT}" pm-enable --yes stage_file_proxy
-        - drush -r "${DOCROOT}" variable-set stage_file_proxy_origin
-          "http://www.example.com"
+        - drush -r "${DOCROOT}" variable-set stage_file_proxy_origin "http://www.example.com"
 
       # Commands that build the site. This is where you would add things
       # like feature reverts or any other drush commands required to
@@ -147,8 +139,7 @@ services:
         - rm /tmp/database.sql.gz
 ```
 
-Want to know more about something mentioned in the comments of this config file?
-Check out these topics:
+Want to know more about something mentioned in the comments of this config file? Check out these topics:
 
 - [Name your Service](/setting-up-services/how-to-set-up-services/name-your-service/)
 - [Specify a Service image](/setting-up-services/how-to-set-up-services/specify-a-service-image/)
@@ -161,6 +152,5 @@ Check out these topics:
 
 ## Start Building Previews!
 
-Once the Tugboat configuration file is committed to your git repository, you can
-start
+Once the Tugboat configuration file is committed to your git repository, you can start
 [building previews](/building-a-preview/administer-previews/build-previews/)!

--- a/content/starter-configs/tutorials/drupal-8.md
+++ b/content/starter-configs/tutorials/drupal-8.md
@@ -4,20 +4,17 @@ date: 2019-09-19T10:59:21-04:00
 weight: 2
 ---
 
-Wondering how to configure Tugboat for a typical Drupal 8 repository? Every
-Drupal site tends to have slightly different requirements, so you may need to do
-more customizing, but this should get you started.
+Wondering how to configure Tugboat for a typical Drupal 8 repository? Every Drupal site tends to have slightly different
+requirements, so you may need to do more customizing, but this should get you started.
 
 ## Configure Drupal
 
-A common practice for managing Drupal's `settings.php` is to leave sensitive
-information, such as database credentials, out of it and commit it to git. Then,
-the sensitive information is loaded from a `settings.local.php` file that exists
+A common practice for managing Drupal's `settings.php` is to leave sensitive information, such as database credentials,
+out of it and commit it to git. Then, the sensitive information is loaded from a `settings.local.php` file that exists
 only on the Drupal installation location.
 
-This pattern works very well with Tugboat. It lets you keep a Tugboat-specific
-set of configurations in your repository, where you can copy it into place with
-a
+This pattern works very well with Tugboat. It lets you keep a Tugboat-specific set of configurations in your repository,
+where you can copy it into place with a
 [configuration file command](/setting-up-services/how-to-set-up-services/leverage-service-commands/).
 
 Add or uncomment the following at the end of `settings.php`
@@ -28,8 +25,7 @@ if (file_exists($app_root . '/' . $site_path . '/settings.local.php')) {
 }
 ```
 
-Add a file to the git repository at `.tugboat/settings.local.php` with the
-following content:
+Add a file to the git repository at `.tugboat/settings.local.php` with the following content:
 
 ```php
 <?php
@@ -49,11 +45,9 @@ $settings['hash_salt'] = hash('sha256', getenv('TUGBOAT_REPO_ID'));
 
 ## Configure Tugboat
 
-The Tugboat configuration is managed by a
-[YAML file](/setting-up-tugboat/create-a-tugboat-config-file/) at
-`.tugboat/config.yml` in the git repository. Here's a basic Drupal 8
-configuration you can use as a starting point, with comments to explain what's
-going on:
+The Tugboat configuration is managed by a [YAML file](/setting-up-tugboat/create-a-tugboat-config-file/) at
+`.tugboat/config.yml` in the git repository. Here's a basic Drupal 8 configuration you can use as a starting point, with
+comments to explain what's going on:
 
 ```yaml
 services:
@@ -80,8 +74,7 @@ services:
         - a2enmod headers rewrite
 
         # Install drush-launcher, if desired.
-        - wget -O /usr/local/bin/drush
-          https://github.com/drush-ops/drush-launcher/releases/download/0.6.0/drush.phar
+        - wget -O /usr/local/bin/drush https://github.com/drush-ops/drush-launcher/releases/download/0.6.0/drush.phar
         - chmod +x /usr/local/bin/drush
 
         # Link the document root to the expected path. This example links /web
@@ -102,8 +95,7 @@ services:
       # already be present.
       update:
         # Use the tugboat-specific Drupal settings.
-        - cp "${TUGBOAT_ROOT}/.tugboat/settings.local.php"
-          "${DOCROOT}/sites/default/"
+        - cp "${TUGBOAT_ROOT}/.tugboat/settings.local.php" "${DOCROOT}/sites/default/"
 
         # Install/update packages managed by composer, including drush.
         - composer install --optimize-autoloader
@@ -111,8 +103,7 @@ services:
         # Copy Drupal's public files directory from an external server. The
         # public SSH key found in the Tugboat Repository configuration must be
         # copied to the external server in order to use rsync over SSH.
-        - rsync -av --delete user@example.com:/path/to/files/
-          "${DOCROOT}/sites/default/files/"
+        - rsync -av --delete user@example.com:/path/to/files/ "${DOCROOT}/sites/default/files/"
         - chgrp -R www-data "${DOCROOT}/sites/default/files"
         - find "${DOCROOT}/sites/default/files" -type d -exec chmod 2775 {} \;
         - find "${DOCROOT}/sites/default/files" -type f -exec chmod 0664 {} \;
@@ -124,8 +115,7 @@ services:
         # This results in smaller previews and reduces the build time.
         - composer require --dev drupal/stage_file_proxy
         - drush pm:enable --yes stage_file_proxy
-        - drush config:set --yes stage_file_proxy.settings origin
-          "http://www.example.com"
+        - drush config:set --yes stage_file_proxy.settings origin "http://www.example.com"
 
       # Commands that build the site. This is where you would add things
       # like feature reverts or any other drush commands required to
@@ -161,8 +151,7 @@ services:
         - rm /tmp/database.sql.gz
 ```
 
-Want to know more about something mentioned in the comments of this config file?
-Check out these topics:
+Want to know more about something mentioned in the comments of this config file? Check out these topics:
 
 - [Name your Service](/setting-up-services/how-to-set-up-services/name-your-service/)
 - [Specify a Service image](/setting-up-services/how-to-set-up-services/specify-a-service-image/)
@@ -175,6 +164,5 @@ Check out these topics:
 
 ## Start Building Previews!
 
-Once the Tugboat configuration file is committed to your git repository, you can
-start
+Once the Tugboat configuration file is committed to your git repository, you can start
 [building previews](/building-a-preview/administer-previews/build-previews/)!

--- a/content/starter-configs/tutorials/pantheon.md
+++ b/content/starter-configs/tutorials/pantheon.md
@@ -4,95 +4,79 @@ date: 2019-09-19T11:00:09-04:00
 weight: 3
 ---
 
-Wondering how to configure Tugboat for a typical site hosted on Pantheon? While
-these instructions are for a Drupal 8 site, the concepts should apply for any
-PHP site hosted by Pantheon. Check out the [Drupal 7](../drupal-7/) and
+Wondering how to configure Tugboat for a typical site hosted on Pantheon? While these instructions are for a Drupal 8
+site, the concepts should apply for any PHP site hosted by Pantheon. Check out the [Drupal 7](../drupal-7/) and
 [WordPress](../wordpress/) tutorials for comparisons.
 
-{{% notice warning %}} These instructions assume you have already configured an
-external git repository provider such as GitHub, GitLab, or BitBucket. Pantheon
-has documentation on
-[how to use GitHub](https://pantheon.io/docs/guides/build-tools/).
-{{% /notice %}}
+{{% notice warning %}} These instructions assume you have already configured an external git repository provider such as
+GitHub, GitLab, or BitBucket. Pantheon has documentation on
+[how to use GitHub](https://pantheon.io/docs/guides/build-tools/). {{% /notice %}}
 
 ## Configure Terminus
 
-Tugboat will need to use Pantheon's
-[terminus](https://pantheon.io/docs/terminus) tool to import a copy of the
-database and files into a Tugboat Preview.
+Tugboat will need to use Pantheon's [terminus](https://pantheon.io/docs/terminus) tool to import a copy of the database
+and files into a Tugboat Preview.
 
 ### Create a Pantheon User for Tugboat
 
-{{% notice warning %}} Because of how terminus machine tokens work, you cannot
-restrict their access to a single Pantheon project. This means that by sharing
-your machine token with Tugboat, anyone else that has access to your Tugboat
-project could gain access to your personal Pantheon account, including any other
-Pantheon projects that account has access to. {{% /notice %}}
+{{% notice warning %}} Because of how terminus machine tokens work, you cannot restrict their access to a single
+Pantheon project. This means that by sharing your machine token with Tugboat, anyone else that has access to your
+Tugboat project could gain access to your personal Pantheon account, including any other Pantheon projects that account
+has access to. {{% /notice %}}
 
-By creating a Pantheon account solely for Tugboat's use, that user's access can
-be restricted to the Pantheon project connected to Tugboat. This user's machine
-token can then be safely shared with Tugboat.
+By creating a Pantheon account solely for Tugboat's use, that user's access can be restricted to the Pantheon project
+connected to Tugboat. This user's machine token can then be safely shared with Tugboat.
 
-1.  If you're logged in to your personal account on Pantheon,
-    [log out](https://dashboard.pantheon.io/logout).
-2.  [Register a new account](https://dashboard.pantheon.io/register) on
-    Pantheon.
+1.  If you're logged in to your personal account on Pantheon, [log out](https://dashboard.pantheon.io/logout).
+2.  [Register a new account](https://dashboard.pantheon.io/register) on Pantheon.
 3.  Specify a unique email address, ideally using an email alias.
 4.  Name your user something recognizable, like _Tugboat User_.
 
 ![Screenshot: Create a new pantheon account](/_images/pantheon-register.png)
 
-{{% notice tip %}} Many email clients allow you to generate aliases, or allow
-you to dynamically have an alias. For example, on gmail, if your email address
-is `dorothy@gmail.com`, you could use the `+` symbol followed by a unique string
-to create an alias for this tugboat user, e.g.
-`dorothy+tugboat-pantheon@gmail.com`. {{% /notice %}}
+{{% notice tip %}} Many email clients allow you to generate aliases, or allow you to dynamically have an alias. For
+example, on gmail, if your email address is `dorothy@gmail.com`, you could use the `+` symbol followed by a unique
+string to create an alias for this tugboat user, e.g. `dorothy+tugboat-pantheon@gmail.com`. {{% /notice %}}
 
 ### Generate a Pantheon Machine Token
 
-Now that we have a new user that Tugboat can use, we will need to generate a
-machine token for this account on Pantheon. While logged in as this new user, go
-to
-[Machine Tokens](https://dashboard.pantheon.io/user?destination=%2Fuser#account/tokens/create/terminus/),
-which is under your account settings. You can name this token whatever you'd
-like, such as `Terminus on Tugboat`:
+Now that we have a new user that Tugboat can use, we will need to generate a machine token for this account on Pantheon.
+While logged in as this new user, go to
+[Machine Tokens](https://dashboard.pantheon.io/user?destination=%2Fuser#account/tokens/create/terminus/), which is under
+your account settings. You can name this token whatever you'd like, such as `Terminus on Tugboat`:
 
 ![Screenshot: New machine token form](/_images/pantheon-new-token.png)
 
-Once you've picked a name, click _Generate Token_. You will then be presented
-with a screen that displays your machine token. **Store this token in a secure
-place, such as a password manager or OS keychain.**
+Once you've picked a name, click _Generate Token_. You will then be presented with a screen that displays your machine
+token. **Store this token in a secure place, such as a password manager or OS keychain.**
 
 ![Screenshot: Token generated modal](/_images/pantheon-token-generated.png)
 
 ### Add your new Pantheon user to your Pantheon project
 
-Now that you've generated a machine token for your new Pantheon user, you still
-need to add this user to your Pantheon project. To do this:
+Now that you've generated a machine token for your new Pantheon user, you still need to add this user to your Pantheon
+project. To do this:
 
 1. Log out of Pantheon.
 2. Log back in with your personal Pantheon account.
 3. Navigate to your Pantheon project, and click _Team_ from the header.
-4. Enter the email address of the new Pantheon user you created above, and click
-   the _Add to team_ button.
+4. Enter the email address of the new Pantheon user you created above, and click the _Add to team_ button.
 
 ![Screenshot: Pantheon Add to team](/_images/pantheon-add-to-team.png)
 
 ### Store the machine token as a Tugboat environment variable
 
-{{% notice warning %}} For the security of your Pantheon site, it's important to
-use an environment variable to store the machine token, instead of committing it
-to your repository or storing it in some other fashion. {{% /notice %}}
+{{% notice warning %}} For the security of your Pantheon site, it's important to use an environment variable to store
+the machine token, instead of committing it to your repository or storing it in some other fashion. {{% /notice %}}
 
 ## Configure Pantheon (using a Drupal example)
 
-A common practice for managing Drupal's `settings.php` is to leave sensitive
-information, such as database credentials, out of it and commit it to git. Then,
-the sensitive information is loaded from a `settings.local.php` file that exists
+A common practice for managing Drupal's `settings.php` is to leave sensitive information, such as database credentials,
+out of it and commit it to git. Then, the sensitive information is loaded from a `settings.local.php` file that exists
 only on the Drupal installation location.
 
-This pattern works very well with Tugboat. It lets you keep a tugboat-specific
-set of configurations in your repository where you can copy it into place with a
+This pattern works very well with Tugboat. It lets you keep a tugboat-specific set of configurations in your repository
+where you can copy it into place with a
 [configuration file command](/setting-up-services/how-to-set-up-services/leverage-service-commands/).
 
 Add or uncomment the following at the end of `settings.php`
@@ -103,8 +87,7 @@ if (file_exists($app_root . '/' . $site_path . '/settings.local.php')) {
 }
 ```
 
-Add a file to the git repository at `.tugboat/settings.local.php` with the
-following content:
+Add a file to the git repository at `.tugboat/settings.local.php` with the following content:
 
 ```php
 <?php
@@ -126,39 +109,32 @@ There are three parts to configuring Tugboat to work with Pantheon.
 
 1. Figure out which version of PHP to use.
 2. Set up a few Tugboat custom environment variables.
-3. Create a
-   [configuration file](/setting-up-tugboat/create-a-tugboat-config-file/) to
-   include in your git repository.
+3. Create a [configuration file](/setting-up-tugboat/create-a-tugboat-config-file/) to include in your git repository.
 
 ### PHP Version
 
-In order to replicate the Pantheon environment as closely as possible, we need
-to use the same version of PHP.
+In order to replicate the Pantheon environment as closely as possible, we need to use the same version of PHP.
 
-{{% notice warning %}} While in theory you could use the `terminus site:info`
-command to determine the PHP version, we've found that may not give you accurate
-results. {{% /notice %}}
+{{% notice warning %}} While in theory you could use the `terminus site:info` command to determine the PHP version,
+we've found that may not give you accurate results. {{% /notice %}}
 
 1.  Log into the [Pantheon Dashboard](https://dashboard.pantheon.io).
 2.  Navigate to the project you are trying to connect with Pantheon.
 3.  Click the Settings gear in the upper right.
     ![Click on Settings in Pantheon Dashboard](/_images/pantheon-settings.png)
-4.  Once in Settings, you should see a PHP Version tab to the far right. After
-    clicking that, you should see the PHP Version.
-    ![Click on PHP Version in Pantheon Settings](/_images/pantheon-php-settings.png)
+4.  Once in Settings, you should see a PHP Version tab to the far right. After clicking that, you should see the PHP
+    Version. ![Click on PHP Version in Pantheon Settings](/_images/pantheon-php-settings.png)
 
 ### Environment Variables
 
 The Tugboat configuration file below makes use of some Tugboat
-[custom environment variables](/setting-up-services/how-to-set-up-services/custom-environment-variables/).
-This is how we securely store the
-[Pantheon machine token](#generate-a-pantheon-machine-token) from above, so you
-don't have to commit it to your git repository. We also define the Pantheon site
-and environment names here to make the config file more portable.
+[custom environment variables](/setting-up-services/how-to-set-up-services/custom-environment-variables/). This is how
+we securely store the [Pantheon machine token](#generate-a-pantheon-machine-token) from above, so you don't have to
+commit it to your git repository. We also define the Pantheon site and environment names here to make the config file
+more portable.
 
-In the [Tugboat Repository settings](/setting-up-tugboat/select-repo-settings/),
-create the following environment variables. In this example, we are using the
-"live" environment of a Pantheon site named "example".
+In the [Tugboat Repository settings](/setting-up-tugboat/select-repo-settings/), create the following environment
+variables. In this example, we are using the "live" environment of a Pantheon site named "example".
 
 ```
 PANTHEON_MACHINE_TOKEN=ABCDEF123456ABCDEF123456
@@ -168,11 +144,9 @@ PANTHEON_SOURCE_ENVIRONMENT=live
 
 ### Tugboat Configuration File
 
-The main Tugboat configuration is managed by a
-[YAML file](/setting-up-tugboat/create-a-tugboat-config-file/) at
-`.tugboat/config.yml` in the git repository. Here's a Pantheon Drupal 8
-configuration you can use as a starting point, with comments to explain what's
-going on:
+The main Tugboat configuration is managed by a [YAML file](/setting-up-tugboat/create-a-tugboat-config-file/) at
+`.tugboat/config.yml` in the git repository. Here's a Pantheon Drupal 8 configuration you can use as a starting point,
+with comments to explain what's going on:
 
 ```yaml
 services:
@@ -267,8 +241,7 @@ services:
     image: tugboatqa/mysql:5
 ```
 
-Want to know more about something mentioned in the comments of this config file?
-Check out these topics:
+Want to know more about something mentioned in the comments of this config file? Check out these topics:
 
 - [Name your Service](/setting-up-services/how-to-set-up-services/name-your-service/)
 - [Specify a Service image](/setting-up-services/how-to-set-up-services/specify-a-service-image/)
@@ -281,6 +254,5 @@ Check out these topics:
 
 ## Start Building Previews!
 
-Once the Tugboat configuration file is committed to your git repository, you can
-start
+Once the Tugboat configuration file is committed to your git repository, you can start
 [building previews](/building-a-preview/administer-previews/build-previews/)!

--- a/content/starter-configs/tutorials/wordpress.md
+++ b/content/starter-configs/tutorials/wordpress.md
@@ -4,20 +4,17 @@ date: 2019-09-19T11:00:57-04:00
 weight: 4
 ---
 
-Wondering how to configure Tugboat for a standard WordPress repository? Every
-site tends to have slightly different requirements, so you may need to do more
-customizing, but this should get you started.
+Wondering how to configure Tugboat for a standard WordPress repository? Every site tends to have slightly different
+requirements, so you may need to do more customizing, but this should get you started.
 
 ## Configure WordPress
 
-For WordPress to use environment-specific settings, you'll need to make some
-changes to `wp-config.php`. One way to do this is to commit a "default" version
-of the file to the git repository, and include a "local" config file with
-override options. That local file should not be included in the git repository.
+For WordPress to use environment-specific settings, you'll need to make some changes to `wp-config.php`. One way to do
+this is to commit a "default" version of the file to the git repository, and include a "local" config file with override
+options. That local file should not be included in the git repository.
 
-These are the settings we are particularly interested in for Tugboat, but the
-the concept could be extended to cover the remaining settings in
-`wp-config.php`:
+These are the settings we are particularly interested in for Tugboat, but the the concept could be extended to cover the
+remaining settings in `wp-config.php`:
 
 ```php
 if ( file_exists( dirname( __FILE__ ) . '/wp-config.local.php' ) )
@@ -41,8 +38,7 @@ if ( !defined('DB_HOST') )
     define('DB_HOST', 'localhost');
 ```
 
-Add a file to the git repository at `.tugboat/wp-config.local.php` with the
-following contents:
+Add a file to the git repository at `.tugboat/wp-config.local.php` with the following contents:
 
 ```php
 <?php
@@ -54,11 +50,9 @@ define('DB_HOST', 'mysql';
 
 ## Configure Tugboat
 
-The Tugboat configuration is managed by a
-[YAML file](/setting-up-tugboat/create-a-tugboat-config-file/) at
-.tugboat/config.yml in the git repository. Here's a basic WordPress
-configuration you can use as a starting point, with comments to explain what's
-going on:
+The Tugboat configuration is managed by a [YAML file](/setting-up-tugboat/create-a-tugboat-config-file/) at
+.tugboat/config.yml in the git repository. Here's a basic WordPress configuration you can use as a starting point, with
+comments to explain what's going on:
 
 ```yaml
 services:
@@ -88,8 +82,7 @@ services:
         - docker-php-ext-install mysqli
 
         # Install wp-cli
-        - curl -O
-          https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
+        - curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
         - cmod +x wp-cli.phar
         - mv wp-cli.phar /usr/local/bin/wp
 
@@ -109,8 +102,7 @@ services:
         # SSH key found in the Tugboat Repository configuration must be
         # copied to the external server in order to use rsync over SSH.
         - mkdir -p "${DOCROOT}/wp-content/uploads" || /bin/true
-        - rsync -av --delete user@example.com:/path/to/wp-content/uploads/
-          "${DOCROOT}/wp-content/uploads/"
+        - rsync -av --delete user@example.com:/path/to/wp-content/uploads/ "${DOCROOT}/wp-content/uploads/"
         - chgrp -R www-data "${DOCROOT}/wp-content/uploads"
         - find "${DOCROOT}/wp-content/uploads" -type d -exec chmod 2775 {} \;
         - find "${DOCROOT}/wp-content/uploads" -type f -exec chmod 0664 {} \;
@@ -151,8 +143,7 @@ services:
         - rm /tmp/database.sql.gz
 ```
 
-Want to know more about something mentioned in the comments of this config file?
-Check out these topics:
+Want to know more about something mentioned in the comments of this config file? Check out these topics:
 
 - [Name your Service](/setting-up-services/how-to-set-up-services/name-your-service/)
 - [Specify a Service image](/setting-up-services/how-to-set-up-services/specify-a-service-image/)
@@ -165,6 +156,5 @@ Check out these topics:
 
 ## Start Building Previews!
 
-Once the Tugboat configuration file is committed to your git repository, you can
-start
+Once the Tugboat configuration file is committed to your git repository, you can start
 [building previews](/building-a-preview/administer-previews/build-previews/)!

--- a/content/support/_index.md
+++ b/content/support/_index.md
@@ -14,6 +14,6 @@ Getting used to a new tool can sometimes be a little overwhelming.
 
 Don’t fret—we’re here for you!
 
-- Join our [Slack support channel](https://launchpass.com/tugboatqa) to connect
-  with Tugboat's developers, and fellow developers who are using Tugboat.
+- Join our [Slack support channel](https://launchpass.com/tugboatqa) to connect with Tugboat's developers, and fellow
+  developers who are using Tugboat.
 - Shoot us an email anytime at [support@tugboat.qa](mailto:support@tugboat.qa).

--- a/content/troubleshooting/debug-config-file.md
+++ b/content/troubleshooting/debug-config-file.md
@@ -9,37 +9,32 @@ weight: 3
 
 ## Process for debugging Tugboat config files
 
-When you're not getting the Tugboat Preview Build you're looking for, there are
-a few ways you might approach debugging your config files:
+When you're not getting the Tugboat Preview Build you're looking for, there are a few ways you might approach debugging
+your config files:
 
 - [Debugging your first Tugboat build config file](#debugging-your-first-tugboat-build-config-file)
 - [Debugging changes to your Tugboat config file](#debugging-changes-to-your-tugboat-config-file)
 
 ### Debugging your first Tugboat build config file
 
-When you're first getting Tugboat set up, here's how we recommend getting
-started and debugging your initial config file:
+When you're first getting Tugboat set up, here's how we recommend getting started and debugging your initial config
+file:
 
 1. Create a branch within your git repository for adding Tugboat, and put your
    [config file there](/setting-up-tugboat/create-a-tugboat-config-file/).
-2. [Build a Preview](/building-a-preview/administer-previews/build-previews/)
-   from that branch.
-3. If you get an error while building the Preview, take a
-   [look at the Preview log](#how-to-check-the-preview-logs).
-4. Click {{% ui-text %}}Full Log{{% /ui-text %}} to make sure you're viewing the
-   entire log.
+2. [Build a Preview](/building-a-preview/administer-previews/build-previews/) from that branch.
+3. If you get an error while building the Preview, take a [look at the Preview log](#how-to-check-the-preview-logs).
+4. Click {{% ui-text %}}Full Log{{% /ui-text %}} to make sure you're viewing the entire log.
 5. Review the log until you see where the Preview build failed.
 
-In some cases, you'll be able to see the specific command where the Preview
-build failed. When that's the case, click the
-{{% ui-text %}}Terminal{{% /ui-text %}} link next to the Service where the
-command error occurred, and you'll get a terminal directly into that Service.
+In some cases, you'll be able to see the specific command where the Preview build failed. When that's the case, click
+the {{% ui-text %}}Terminal{{% /ui-text %}} link next to the Service where the command error occurred, and you'll get a
+terminal directly into that Service.
 
 ![Terminal directly into the Service](/_images/troubleshooting-terminal-into-service.png)
 
-From here, you can go line-by-line through the commands in your config file to
-see what happens when you're running them directly in the terminal. You may want
-to pass a verbose flag to see more context about what's going on.
+From here, you can go line-by-line through the commands in your config file to see what happens when you're running them
+directly in the terminal. You may want to pass a verbose flag to see more context about what's going on.
 
 Common problems here include:
 
@@ -47,15 +42,13 @@ Common problems here include:
 - Missing apps
 - Installs that didn't execute as expected
 
-If you can't see the exact command where the Preview build failed, or if you're
-not having any luck manually debugging your config file, reach out to us via
-[Help and Support](/support/) - we're happy to help!
+If you can't see the exact command where the Preview build failed, or if you're not having any luck manually debugging
+your config file, reach out to us via [Help and Support](/support/) - we're happy to help!
 
 ### Debugging changes to your Tugboat config file
 
-If you're making changes to your Tugboat config file, the debugging process is
-mostly the same as when you first set it up, but there are a few things you want
-to do to make sure Tugboat is getting the changes as expected:
+If you're making changes to your Tugboat config file, the debugging process is mostly the same as when you first set it
+up, but there are a few things you want to do to make sure Tugboat is getting the changes as expected:
 
 1. Create a branch within your git repository for your changes, and put your new
    [config file there](/setting-up-tugboat/create-a-tugboat-config-file/).
@@ -63,33 +56,27 @@ to do to make sure Tugboat is getting the changes as expected:
 3. Go into Tugboat, and manually
    [build your Preview without a Base Preview](/building-a-preview/work-with-base-previews/building-new-previews/).
 
-{{% notice tip %}} If you're using a Base Preview in your Tugboat project,
-subsequent Previews that are built from that Base Preview start with the
-commands in `build`, bypassing `init` and `update`. Changes you make to a config
-file's `init` or `update` commands won't be applied when automatically building
-a Preview from a PR. You'll need to manually rebuild a Preview from scratch if
-you're using a Base Preview in order to apply config file changes. For more
-info, see:
+{{% notice tip %}} If you're using a Base Preview in your Tugboat project, subsequent Previews that are built from that
+Base Preview start with the commands in `build`, bypassing `init` and `update`. Changes you make to a config file's
+`init` or `update` commands won't be applied when automatically building a Preview from a PR. You'll need to manually
+rebuild a Preview from scratch if you're using a Base Preview in order to apply config file changes. For more info, see:
 [The build process: explained](/building-a-preview/preview-deep-dive/how-previews-work/#the-build-process-explained).
 {{% /notice %}}
 
 From here, if your Preview build is failing, the process is the same as above:
 
 1. Take a [look at the Preview log](#how-to-check-the-preview-logs).
-2. Click {{% ui-text %}}Full Log{{% /ui-text %}} to make sure you're viewing the
-   entire log.
+2. Click {{% ui-text %}}Full Log{{% /ui-text %}} to make sure you're viewing the entire log.
 3. Review the log until you see where the Preview build failed.
 
-In some cases, you'll be able to see the specific command where the Preview
-build failed. When that's the case, click the
-{{% ui-text %}}Terminal{{% /ui-text %}} link next to the Service where the
-command error occurred, and you'll get a terminal directly into that Service.
+In some cases, you'll be able to see the specific command where the Preview build failed. When that's the case, click
+the {{% ui-text %}}Terminal{{% /ui-text %}} link next to the Service where the command error occurred, and you'll get a
+terminal directly into that Service.
 
 ![Terminal directly into the Service](/_images/troubleshooting-terminal-into-service.png)
 
-From here, you can go line-by-line through the commands in your config file to
-see what happens when you're running them directly in the terminal. You may want
-to pass a verbose flag to see more context about what's going on.
+From here, you can go line-by-line through the commands in your config file to see what happens when you're running them
+directly in the terminal. You may want to pass a verbose flag to see more context about what's going on.
 
 Common problems here include:
 
@@ -97,9 +84,8 @@ Common problems here include:
 - Missing apps
 - Installs that didn't execute as expected
 
-If you can't see the exact command where the Preview build failed, or if you're
-not having any luck manually debugging your config file, reach out to us via
-[Help and Support](/support/) - we're happy to help!
+If you can't see the exact command where the Preview build failed, or if you're not having any luck manually debugging
+your config file, reach out to us via [Help and Support](/support/) - we're happy to help!
 
 ## Tools for debugging Tugboat config files
 
@@ -109,26 +95,23 @@ In terms of tools, there are three ways to debug configuration files:
 - [Tugboat's CLI](#debug-via-tugboat-s-cli)
 - [Push changes to git](#debug-via-pushing-changes-to-git)
 
-And you'll definitely want to know
-[how to check the Preview logs](#how-to-check-the-preview-logs).
+And you'll definitely want to know [how to check the Preview logs](#how-to-check-the-preview-logs).
 
 ### Debug by terminal in Tugboat's web UI
 
-When you're viewing a Preview in Tugboat's web UI, you'll have the option to
-open a terminal directly into a Preview's Services:
+When you're viewing a Preview in Tugboat's web UI, you'll have the option to open a terminal directly into a Preview's
+Services:
 
 ![Terminal directly into the Service](/_images/troubleshooting-terminal-into-service.png)
 
-From here, you can manually execute lines from your config file in order to
-figure out exactly where the error is occurring. For more context when you're
-viewing the results of the commands directly in the terminal, you may want to
+From here, you can manually execute lines from your config file in order to figure out exactly where the error is
+occurring. For more context when you're viewing the results of the commands directly in the terminal, you may want to
 pass the verbose flag.
 
 ### Debug via Tugboat's CLI
 
-If you've installed [Tugboat's CLI](/tugboat-cli/), you can debug your Preview
-build from the comfort of your own terminal. Type `tugboat help` for a list of
-commands and options. Following our debug process above, you might:
+If you've installed [Tugboat's CLI](/tugboat-cli/), you can debug your Preview build from the comfort of your own
+terminal. Type `tugboat help` for a list of commands and options. Following our debug process above, you might:
 
 ```shell
 tugboat log 5b04c7d14c3dad00016a2e80
@@ -136,28 +119,24 @@ tugboat ls services preview=5b04c7d14c3dad00016a2e80
 tugboat shell 5d26155195433d189bdf9307
 ```
 
-And once you've got a shell into the Service, you can go line-by-line debugging
-your config file, the same as if you'd used the web UI to terminal into a
-Service.
+And once you've got a shell into the Service, you can go line-by-line debugging your config file, the same as if you'd
+used the web UI to terminal into a Service.
 
 ### Debug via pushing changes to git
 
-If you think you know where the problem is in your config file, you can always
-make the changes, make a PR or push a branch to your git repo, and try again to
-[build the Preview](/building-a-preview/administer-previews/build-previews/).
+If you think you know where the problem is in your config file, you can always make the changes, make a PR or push a
+branch to your git repo, and try again to [build the Preview](/building-a-preview/administer-previews/build-previews/).
 
 The same caveats apply as in
-[Debugging changes to your Tugboat config file](#debugging-changes-to-your-tugboat-config-file)
-above; if you're making changes when a Tugboat project has a Base Preview,
-you'll need to manually rebuild a Preview from scratch if you're using a Base
-Preview in order to apply config file changes. For more info, see:
+[Debugging changes to your Tugboat config file](#debugging-changes-to-your-tugboat-config-file) above; if you're making
+changes when a Tugboat project has a Base Preview, you'll need to manually rebuild a Preview from scratch if you're
+using a Base Preview in order to apply config file changes. For more info, see:
 [The build process: explained](/building-a-preview/preview-deep-dive/how-previews-work/#the-build-process-explained).
 
 ## How to check the Preview logs
 
-You can click into the Preview's name to view the Preview's logs _and_ logs for
-individual Services you're running on a Preview. Alternately, you could use the
-[Tugboat CLI](/tugboat-cli/) to view
+You can click into the Preview's name to view the Preview's logs _and_ logs for individual Services you're running on a
+Preview. Alternately, you could use the [Tugboat CLI](/tugboat-cli/) to view
 [Preview logs](/tugboat-cli/use-the-cli/#view-preview-logs) and
 [Service logs](/tugboat-cli/use-the-cli/#view-services-logs).
 

--- a/content/troubleshooting/fix-problem-x.md
+++ b/content/troubleshooting/fix-problem-x.md
@@ -13,15 +13,13 @@ weight: 4
 
 ## PHP out of memory issues
 
-If you're getting "PHP out of memory errors", you can manually set the memory
-limit higher. If you're using one of the
-[tugboatqa php images](/reference/tugboat-images/), use something like this in
-your build script:
+If you're getting "PHP out of memory errors", you can manually set the memory limit higher. If you're using one of the
+[tugboatqa php images](/reference/tugboat-images/), use something like this in your build script:
 
 `echo "memory_limit = 512M" >> /usr/local/etc/php/conf.d/my-php.ini`
 
-If you would like unlimited memory allocated to PHP command-line scripts, you
-can add the following PHP snippet to your application:
+If you would like unlimited memory allocated to PHP command-line scripts, you can add the following PHP snippet to your
+application:
 
 ```php
 if (PHP_SAPI === 'cli') {
@@ -35,11 +33,10 @@ Or when executing PHP directly:
 
 ## MySQL server has gone away
 
-If you're getting a "MySQL server has gone away" error, you can resolve this by
-increasing the packet size for MySQL.
+If you're getting a "MySQL server has gone away" error, you can resolve this by increasing the packet size for MySQL.
 
-To increase the max_allowed_packet to 512MB during the build stages, add this
-before the mysql commands in the build script:
+To increase the max_allowed_packet to 512MB during the build stages, add this before the mysql commands in the build
+script:
 
 `mysql -e "SET GLOBAL max_allowed_packet=536870912;"`
 
@@ -52,11 +49,9 @@ echo "max_allowed_packet=536870912" >> /etc/mysql/conf.d/tugboat.cnf
 
 ## cd isn't working
 
-Each
-[command](/setting-up-services/how-to-set-up-services/leverage-service-commands/)
-is run in its own context, meaning things like `cd` do not "stick" between
-commands. If that behavior is required, include an external script in the git
-repository and call it from the config file.
+Each [command](/setting-up-services/how-to-set-up-services/leverage-service-commands/) is run in its own context,
+meaning things like `cd` do not "stick" between commands. If that behavior is required, include an external script in
+the git repository and call it from the config file.
 
 1. Add your build steps to a file; for example: `.tugboat/init.sh`
 
@@ -91,71 +86,57 @@ commands:
 
 ### 1064: Command Failed
 
-This error occurs when a command in your config file can't be executed, or
-returns an error. When a Preview build fails with this error:
+This error occurs when a command in your config file can't be executed, or returns an error. When a Preview build fails
+with this error:
 
-1. [Check the Preview logs](../debug-config-file/#how-to-check-the-preview-logs)
-   to see what command was running when the build failed.
+1. [Check the Preview logs](../debug-config-file/#how-to-check-the-preview-logs) to see what command was running when
+   the build failed.
 2. If you don't spot an issue with the command,
-   [terminal into the relevant Service](../debug-config-file/#debug-by-terminal-in-tugboat-s-web-ui)
-   and try executing the command directly to get more context about what's
-   happening.
+   [terminal into the relevant Service](../debug-config-file/#debug-by-terminal-in-tugboat-s-web-ui) and try executing
+   the command directly to get more context about what's happening.
 
-If you're having trouble pinpointing the error, you may need to go back and
-execute your config file commands line-by-line until you find the point at which
-things stop working.
+If you're having trouble pinpointing the error, you may need to go back and execute your config file commands
+line-by-line until you find the point at which things stop working.
 
 {{% notice tip %}} A few common problems in config files include:
 [`cd` does not "stick" between commands](#cd-isn-t-working) and
-[running a background process "breaks" the build](#running-a-background-process).
-Check out the troubleshooting docs for info on addressing these issues.
-{{% /notice %}}
+[running a background process "breaks" the build](#running-a-background-process). Check out the troubleshooting docs for
+info on addressing these issues. {{% /notice %}}
 
-If you've gone through the debugging process and haven't been able to figure out
-why your command is failing, reach out to us at [help and support](/support/) -
-we're happy to take a look!
+If you've gone through the debugging process and haven't been able to figure out why your command is failing, reach out
+to us at [help and support](/support/) - we're happy to take a look!
 
 ### 1074: Repo configuration does not allow building of pull requests from forks
 
 If you're getting this error message, it's because you haven't enabled the
-[repository setting](/setting-up-tugboat/select-repo-settings/) to allow
-building pull requests from forks.
+[repository setting](/setting-up-tugboat/select-repo-settings/) to allow building pull requests from forks.
 
-This setting is off by default, but when it's enabled, Tugboat builds Previews
-for pull requests made to the primary repo from forked repositories. Turning on
-this setting should correct this error.
+This setting is off by default, but when it's enabled, Tugboat builds Previews for pull requests made to the primary
+repo from forked repositories. Turning on this setting should correct this error.
 
-{{% notice warning %}} When you enable this option in a public repository,
-anyone who can submit a pull request from the fork can extract configured
-repository environment variables, as well as the private SSH key generated for
-the repo. The latter is mainly a problem when the repository SSH key is added to
-some other service, like to pull a database or checkout a related git repo.
-However, as an example, if the repository SSH key is allowed to _push_ changes
-to a git repo, a malicious user would then have access to _modify_ that repo.
-{{% /notice %}}
+{{% notice warning %}} When you enable this option in a public repository, anyone who can submit a pull request from the
+fork can extract configured repository environment variables, as well as the private SSH key generated for the repo. The
+latter is mainly a problem when the repository SSH key is added to some other service, like to pull a database or
+checkout a related git repo. However, as an example, if the repository SSH key is allowed to _push_ changes to a git
+repo, a malicious user would then have access to _modify_ that repo. {{% /notice %}}
 
 ## Running a background process
 
-If you try to add a background-process to your
-[config file](/setting-up-tugboat/create-a-tugboat-config-file/) in the
-conventional way, Tugboat will think the Preview has not finished building, and
-it will be stuck in the "building" state until it eventually times out and
-fails.
+If you try to add a background-process to your [config file](/setting-up-tugboat/create-a-tugboat-config-file/) in the
+conventional way, Tugboat will think the Preview has not finished building, and it will be stuck in the "building" state
+until it eventually times out and fails.
 
 For instructions on how to run a background within a Tugboat Preview, see:
 [Setting up Services -> Running a Background Process](/setting-up-services/how-to-set-up-services/running-a-background-process/).
 
 ## My script is missing after a Preview build completes
 
-If you've created a script that "sleeps" in the background while a Preview is
-being built, but that script is missing when the Preview build completes, that's
-an expected behavior. When a Preview build completes, Tugboat stops the
-containers to take
-[the build snapshot](/building-a-preview/preview-deep-dive/how-previews-work/#the-build-snapshot).
-After the data is committed, Tugboat restarts the containers to serve the
-Preview. Any scripts that were waiting for the build to complete will no longer
-be present when the container is restarted.
+If you've created a script that "sleeps" in the background while a Preview is being built, but that script is missing
+when the Preview build completes, that's an expected behavior. When a Preview build completes, Tugboat stops the
+containers to take [the build snapshot](/building-a-preview/preview-deep-dive/how-previews-work/#the-build-snapshot).
+After the data is committed, Tugboat restarts the containers to serve the Preview. Any scripts that were waiting for the
+build to complete will no longer be present when the container is restarted.
 
-To create a one-time script that runs after the Preview build completes, take a
-look at [`runit`'s documentation](http://smarden.org/runit/runsv.8.html) -
-particularly the parts about creating a `finish` script.
+To create a one-time script that runs after the Preview build completes, take a look at
+[`runit`'s documentation](http://smarden.org/runit/runsv.8.html) - particularly the parts about creating a `finish`
+script.

--- a/content/troubleshooting/preview-built-problem.md
+++ b/content/troubleshooting/preview-built-problem.md
@@ -12,102 +12,79 @@ weight: 2
 ## A Preview says it is "ready", but shows a blank page
 
 When a Preview says it is "ready", that means that it successfully ran the
-[commands](/setting-up-services/how-to-set-up-services/leverage-service-commands)
-in your [configuration file](/setting-up-tugboat/create-a-tugboat-config-file/),
-and none of those commands returned an error. It does not necessarily mean that
-those commands did what you expected them to do. For example, your configuration
-might set up a database, but not provide the correct password to some
-application config file. In this case, the Preview would build successfully, but
-the application might not load.
+[commands](/setting-up-services/how-to-set-up-services/leverage-service-commands) in your
+[configuration file](/setting-up-tugboat/create-a-tugboat-config-file/), and none of those commands returned an error.
+It does not necessarily mean that those commands did what you expected them to do. For example, your configuration might
+set up a database, but not provide the correct password to some application config file. In this case, the Preview would
+build successfully, but the application might not load.
 
 To troubleshoot where this might have gone wrong:
 
-1. Double-check the commands in the
-   [configuration file](/setting-up-tugboat/create-a-tugboat-config-file/).
-2. Check
-   [the Preview's logs](../debug-config-file/#how-to-check-the-preview-logs) for
-   any clues, and.
-3. Make use of [Tugboat's terminal access](/tugboat-cli/) to the Preview to do
-   the same type of troubleshooting you would do if this happened on your local
-   installation.
+1. Double-check the commands in the [configuration file](/setting-up-tugboat/create-a-tugboat-config-file/).
+2. Check [the Preview's logs](../debug-config-file/#how-to-check-the-preview-logs) for any clues, and.
+3. Make use of [Tugboat's terminal access](/tugboat-cli/) to the Preview to do the same type of troubleshooting you
+   would do if this happened on your local installation.
 
 ## A Preview is pulling the wrong Docker image
 
-Have you updated the Docker image you want your Preview to use, but it still
-appears to be pulling the old image? There are a couple of things that could be
-in play here:
+Have you updated the Docker image you want your Preview to use, but it still appears to be pulling the old image? There
+are a couple of things that could be in play here:
 
 1. [Verify what version of the image you're calling](#verify-what-version-of-the-image-you-re-calling)
 2. [Not all Preview Actions call the Docker image again](#rebuild-the-preview-from-scratch)
 
 ### Verify what version of the image you're calling
 
-Maybe you thought you had left a version tag off, so you'd be getting the latest
-Docker image, but you had actually called a
-[specific version of the image](/setting-up-services/service-images/image-version-tags)
-in the config file. (Or vice versa! Maybe your config file calls `latest` or
-doesn't specify a version, but you actually need a specific image version.)
-First thing's first; double-check whether you're calling a specific version of
-the Docker image in your
-[config file](/setting-up-tugboat/create-a-tugboat-config-file/), and update as
-necessary.
+Maybe you thought you had left a version tag off, so you'd be getting the latest Docker image, but you had actually
+called a [specific version of the image](/setting-up-services/service-images/image-version-tags) in the config file. (Or
+vice versa! Maybe your config file calls `latest` or doesn't specify a version, but you actually need a specific image
+version.) First thing's first; double-check whether you're calling a specific version of the Docker image in your
+[config file](/setting-up-tugboat/create-a-tugboat-config-file/), and update as necessary.
 
 ### Rebuild the Preview from scratch
 
-The more common issue is performing a Preview Action that doesn't actually call
-the Docker image specified in your config file.
+The more common issue is performing a Preview Action that doesn't actually call the Docker image specified in your
+config file.
 
-If you're building a Preview from a PR, and you've got a Base Preview set in
-your Tugboat project, the Preview from your PR only executes commands in the
-`build` portion of the config file. Your Docker image is pulled before `init`.
+If you're building a Preview from a PR, and you've got a Base Preview set in your Tugboat project, the Preview from your
+PR only executes commands in the `build` portion of the config file. Your Docker image is pulled before `init`.
 
 For more info, see:
 [When does Tugboat pull a Docker image](/setting-up-services/service-images/docker-pull/#when-does-tugboat-pull-a-docker-image),
 and
 [When does Tugboat update a Docker image?](/setting-up-services/service-images/docker-pull/#when-does-tugboat-update-a-docker-image)
 
-Basically, this means building a Preview from a PR when you're using a Base
-Preview will never pull a new Docker image.
+Basically, this means building a Preview from a PR when you're using a Base Preview will never pull a new Docker image.
 
 The practical fix for this issue is to
 [build the Preview from scratch, without using the Base Preview](/building-a-preview/work-with-base-previews/building-new-previews/).
-If you want to change the Docker image in your Base Preview, so all new Previews
-will build from the new image, you'll need to
-[Rebuild](/building-a-preview/work-with-base-previews/change-or-update/#change-a-base-preview)
-the Base Preview.
+If you want to change the Docker image in your Base Preview, so all new Previews will build from the new image, you'll
+need to [Rebuild](/building-a-preview/work-with-base-previews/change-or-update/#change-a-base-preview) the Base Preview.
 
-{{% notice tip %}} If you're using the
-[Repository Setting](/setting-up-tugboat/select-repo-settings/) to
+{{% notice tip %}} If you're using the [Repository Setting](/setting-up-tugboat/select-repo-settings/) to
 [Refresh Base Previews Automatically](/setting-up-tugboat/select-repo-settings/#refresh-base-previews-automatically),
-this does _not_ update the Docker images used in your Preview. This only kicks
-off a
-[Refresh](/building-a-preview/work-with-base-previews/change-or-update/#automatically-refresh-a-base-preview),
-which runs config file commands from both `update` and `build`. You need to
-manually
-[Rebuild a Base Preview](/building-a-preview/work-with-base-previews/change-or-update/#change-a-base-preview)
-to pull a new Docker image. {{% /notice %}}
+this does _not_ update the Docker images used in your Preview. This only kicks off a
+[Refresh](/building-a-preview/work-with-base-previews/change-or-update/#automatically-refresh-a-base-preview), which
+runs config file commands from both `update` and `build`. You need to manually
+[Rebuild a Base Preview](/building-a-preview/work-with-base-previews/change-or-update/#change-a-base-preview) to pull a
+new Docker image. {{% /notice %}}
 
 ## Something in my Preview isn't right
 
-It's possible for a Preview to build, but to be missing something you expect to
-see. This is similar to the
-["Preview says it is "ready", but shows a blank page"](#a-preview-says-it-is-ready-but-shows-a-blank-page)
-issue above; your Preview may not have failed during the build process, but it's
-possible something in the configuration file didn't execute as you expected.
+It's possible for a Preview to build, but to be missing something you expect to see. This is similar to the
+["Preview says it is "ready", but shows a blank page"](#a-preview-says-it-is-ready-but-shows-a-blank-page) issue above;
+your Preview may not have failed during the build process, but it's possible something in the configuration file didn't
+execute as you expected.
 
 To troubleshoot where this might have gone wrong:
 
-1. Double-check the commands in the
-   [configuration file](/setting-up-tugboat/create-a-tugboat-config-file/).
-2. Check
-   [the Preview's logs](../debug-config-file/#how-to-check-the-preview-logs) for
-   any clues.
-3. Make use of [Tugboat's terminal access](/tugboat-cli/) to the Preview to do
-   the same type of troubleshooting you would do if this happened on your local
-   installation.
+1. Double-check the commands in the [configuration file](/setting-up-tugboat/create-a-tugboat-config-file/).
+2. Check [the Preview's logs](../debug-config-file/#how-to-check-the-preview-logs) for any clues.
+3. Make use of [Tugboat's terminal access](/tugboat-cli/) to the Preview to do the same type of troubleshooting you
+   would do if this happened on your local installation.
 
-If you can't figure out why something isn't as you expect in your Preview, let
-us know! Visit us at [Help and Support](/support/); we're happy to help.
+If you can't figure out why something isn't as you expect in your Preview, let us know! Visit us at
+[Help and Support](/support/); we're happy to help.
 
 ## Troubleshooting Visual Diffs
 
@@ -117,11 +94,10 @@ us know! Visit us at [Help and Support](/support/); we're happy to help.
 
 ### Visual diffs aren't displaying, or aren't displaying as I expect
 
-To configure which pages have visual diffs generated, you need to specify the
-relative URLs of the pages in a `visualdiffs` key in the Service definition.
-That information should be in the
-[config file](/setting-up-tugboat/create-a-tugboat-config-file/) of the branch
-or PR that you're building, _not_ the Base Preview.
+To configure which pages have visual diffs generated, you need to specify the relative URLs of the pages in a
+`visualdiffs` key in the Service definition. That information should be in the
+[config file](/setting-up-tugboat/create-a-tugboat-config-file/) of the branch or PR that you're building, _not_ the
+Base Preview.
 
 Some things you might try when troubleshooting a visual diff include:
 
@@ -151,32 +127,25 @@ services:
         waitUntil: domcontentloaded
 ```
 
-If you've verified the relative URLs are correct, and that information is in the
-config file of the branch or PR you're building, but you're still not seeing
-what you expect to see, reach out to us at [help and support](/support/) - we're
+If you've verified the relative URLs are correct, and that information is in the config file of the branch or PR you're
+building, but you're still not seeing what you expect to see, reach out to us at [help and support](/support/) - we're
 happy to take a look!
 
 ### URL not found
 
-If the URL you use when
-[configuring your visual diffs](/visual-diffs/using-visual-diffs/#how-to-configure-visual-diffs)
-doesn't match a _relative URL_ in your site, you may see visual diff panes
-generate, but with "Not Found" message inside the images. If this happens,
-[edit your config file](/setting-up-tugboat/create-a-tugboat-config-file/) to
-specify the _relative URLs_ of the pages you want to diff, and then
-[Rebuild](/building-a-preview/administer-previews/change-or-update-previews/#rebuild-previews)
-the Preview.
+If the URL you use when [configuring your visual diffs](/visual-diffs/using-visual-diffs/#how-to-configure-visual-diffs)
+doesn't match a _relative URL_ in your site, you may see visual diff panes generate, but with "Not Found" message inside
+the images. If this happens, [edit your config file](/setting-up-tugboat/create-a-tugboat-config-file/) to specify the
+_relative URLs_ of the pages you want to diff, and then
+[Rebuild](/building-a-preview/administer-previews/change-or-update-previews/#rebuild-previews) the Preview.
 
 ![URL Not Found in Visual Diff](/_images/visual-diffs-url-not-found.png)
 
 ### There was a problem generating Visual Diffs for this preview.
 
-If there's an issue with the way your visual diffs key is configured, you may
-get the "There was a problem generating Visual Diffs for this preview" error.
-This could be because of the _relative URLs_ in your
-[config file](/setting-up-tugboat/create-a-tugboat-config-file/), or it could be
-that you need to override
+If there's an issue with the way your visual diffs key is configured, you may get the "There was a problem generating
+Visual Diffs for this preview" error. This could be because of the _relative URLs_ in your
+[config file](/setting-up-tugboat/create-a-tugboat-config-file/), or it could be that you need to override
 [the default timeout option](#overriding-the-default-timeout-option) or the
-[default waitUntil option](#overriding-the-default-waituntil-option). If you've
-tried those things, and are still having problems, reach out to us at
-[help and support](/support/) - we're happy to take a look!
+[default waitUntil option](#overriding-the-default-waituntil-option). If you've tried those things, and are still having
+problems, reach out to us at [help and support](/support/) - we're happy to take a look!

--- a/content/troubleshooting/preview-wont-build.md
+++ b/content/troubleshooting/preview-wont-build.md
@@ -20,38 +20,31 @@ Uh oh! Did your Preview Build get stuck?
 
 ### Pending
 
-Your Preview Builds/Rebuilds/Refreshes appear as `Pending` when Tugboat is
-waiting for an available slot in the build queue. If you {{% ui-text %}}Cancel
-{{% /ui-text %}} and then retry the process, most of the time, your Preview
-loses its spot in line and goes back to the end of the queue.
+Your Preview Builds/Rebuilds/Refreshes appear as `Pending` when Tugboat is waiting for an available slot in the build
+queue. If you {{% ui-text %}}Cancel {{% /ui-text %}} and then retry the process, most of the time, your Preview loses
+its spot in line and goes back to the end of the queue.
 
-Give it some time, and if you're still having issues, contact us at
-[Help and Support](/support/).
+Give it some time, and if you're still having issues, contact us at [Help and Support](/support/).
 
 ### Building
 
-Has your Preview been building for a long time? There are a couple of things to
-check:
+Has your Preview been building for a long time? There are a couple of things to check:
 
-Take a look at your Repository Stats to see how long your average build time is.
-If your Preview has been building for less than that time, hang in there; if it
-has been in `building` for significantly longer, it might be time to
+Take a look at your Repository Stats to see how long your average build time is. If your Preview has been building for
+less than that time, hang in there; if it has been in `building` for significantly longer, it might be time to
 troubleshoot.
 
 ![View average build time in Repository Stats](/_images/repo-stats-build-time.png)
 
 When you're ready to troubleshoot, start by taking a
-[look at the Preview's logs](../debug-config-file/#how-to-check-the-preview-logs).
-Logs should give you some insight into where the Preview is in the build
-process. If you see that the Preview build isn't progressing, checking out where
-it got stuck is a great place to start
-[debugging the Config file](../debug-config-file/) and figuring out what's
+[look at the Preview's logs](../debug-config-file/#how-to-check-the-preview-logs). Logs should give you some insight
+into where the Preview is in the build process. If you see that the Preview build isn't progressing, checking out where
+it got stuck is a great place to start [debugging the Config file](../debug-config-file/) and figuring out what's
 causing the Preview build to hang.
 
-If your builds are taking longer than expected, but there isn't an issue in your
-config file causing problems, take a look at
-[Optimize your Preview builds](/building-a-preview/preview-deep-dive/optimize-preview-builds/)
-for a few things you might try:
+If your builds are taking longer than expected, but there isn't an issue in your config file causing problems, take a
+look at [Optimize your Preview builds](/building-a-preview/preview-deep-dive/optimize-preview-builds/) for a few things
+you might try:
 
 - [Use Service Commands to create a Base Preview that does the heavy lifting](/building-a-preview/preview-deep-dive/optimize-preview-builds/#use-service-commands-to-create-a-base-preview-that-does-the-heavy-lifting)
 - [Use the Auto Refresh Base Preview functionality to update large assets](/building-a-preview/preview-deep-dive/optimize-preview-builds/#use-the-auto-refresh-base-preview-functionality-to-update-large-assets)
@@ -61,34 +54,28 @@ for a few things you might try:
 
 ### Rebuilding
 
-Preview hung on `rebuilding`? Take a look at your Repository Stats to see how
-long your average build time is. If your Preview has been building for less than
-that time, hang in there; if it has been in `rebuilding` for significantly
+Preview hung on `rebuilding`? Take a look at your Repository Stats to see how long your average build time is. If your
+Preview has been building for less than that time, hang in there; if it has been in `rebuilding` for significantly
 longer, it might be time to troubleshoot.
 
 ![View average build time in Repository Stats](/_images/repo-stats-build-time.png)
 
 When you're ready to troubleshoot, start by taking a
-[look at the Preview's logs](../debug-config-file/#how-to-check-the-preview-logs).
-Logs should give you some insight into where the Preview is in the rebuild
-process. If you see that the Preview build isn't progressing, checking out where
-it got stuck is a great place to start
-[debugging the Config file](../debug-config-file/) and figuring out what's
+[look at the Preview's logs](../debug-config-file/#how-to-check-the-preview-logs). Logs should give you some insight
+into where the Preview is in the rebuild process. If you see that the Preview build isn't progressing, checking out
+where it got stuck is a great place to start [debugging the Config file](../debug-config-file/) and figuring out what's
 causing the Preview rebuild to hang.
 
-{{% notice tip %}} If you're rebuilding a Preview that was generated without a
-Base Preview, the rebuild process starts with the commands in `init`. If you're
-rebuilding a Preview that was generated from a Base Preview, rebuild starts with
-the commands in `build`. Which type of Rebuild you're doing should tell you
-where you start looking for problems in the config file - during `init` or
-skipping straight to `build` commands. For more info, see:
+{{% notice tip %}} If you're rebuilding a Preview that was generated without a Base Preview, the rebuild process starts
+with the commands in `init`. If you're rebuilding a Preview that was generated from a Base Preview, rebuild starts with
+the commands in `build`. Which type of Rebuild you're doing should tell you where you start looking for problems in the
+config file - during `init` or skipping straight to `build` commands. For more info, see:
 [The build process: explained](/building-a-preview/preview-deep-dive/how-previews-work/#the-build-process-explained).
 {{% /notice %}}
 
-If your rebuilds are taking longer than expected, but there isn't an issue in
-your config file causing problems, take a look at
-[Optimize your Preview builds](/building-a-preview/preview-deep-dive/optimize-preview-builds/)
-for a few things you might try:
+If your rebuilds are taking longer than expected, but there isn't an issue in your config file causing problems, take a
+look at [Optimize your Preview builds](/building-a-preview/preview-deep-dive/optimize-preview-builds/) for a few things
+you might try:
 
 - [Use Service Commands to create a Base Preview that does the heavy lifting](/building-a-preview/preview-deep-dive/optimize-preview-builds/#use-service-commands-to-create-a-base-preview-that-does-the-heavy-lifting)
 - [Use the Auto Refresh Base Preview functionality to update large assets](/building-a-preview/preview-deep-dive/optimize-preview-builds/#use-the-auto-refresh-base-preview-functionality-to-update-large-assets)
@@ -98,25 +85,22 @@ for a few things you might try:
 
 ### Refreshing
 
-Preview hung on `refreshing`? Take a look at your Repository Stats to see how
-long your average build time is. If your Preview has been refreshing for less
-than that time, hang in there; if it has been in `refreshing` for significantly
+Preview hung on `refreshing`? Take a look at your Repository Stats to see how long your average build time is. If your
+Preview has been refreshing for less than that time, hang in there; if it has been in `refreshing` for significantly
 longer, it might be time to troubleshoot.
 
 ![View average build time in Repository Stats](/_images/repo-stats-build-time.png)
 
 When you're ready to troubleshoot, start by taking a
-[look at the Preview's logs](../debug-config-file/#how-to-check-the-preview-logs).
-Logs should give you some insight into where the Preview is in the refresh
-process. If you see that the Preview refresh isn't progressing, checking out
-where it got stuck is a great place to start
-[debugging the Config file](../debug-config-file/) and figuring out what's
+[look at the Preview's logs](../debug-config-file/#how-to-check-the-preview-logs). Logs should give you some insight
+into where the Preview is in the refresh process. If you see that the Preview refresh isn't progressing, checking out
+where it got stuck is a great place to start [debugging the Config file](../debug-config-file/) and figuring out what's
 causing the Preview rebuild to hang.
 
 ### Canceling
 
-If you've decided to cancel a Preview Action, but the Preview is stuck on
-`canceling`, there are a couple of things you can try:
+If you've decided to cancel a Preview Action, but the Preview is stuck on `canceling`, there are a couple of things you
+can try:
 
 1. Hang in and wait a bit longer.
 2. Force-delete a stuck Preview from the [Tugboat CLI](/tugboat-cli/).
@@ -125,36 +109,29 @@ If you've decided to cancel a Preview Action, but the Preview is stuck on
 ## Troubleshooting a Preview Build Failure
 
 If your Tugboat Preview has `failed` to build, it's time to take a
-[look at the Preview logs](../debug-config-file/#how-to-check-the-preview-logs).
-The most common cause of build failures is when one of the commands in the
-Tugboat [configuration file](/setting-up-tugboat/create-a-tugboat-config-file/)
-exits with an error. If that is the case, it's time to start
-[debugging the configuration file](../debug-config-file/).
+[look at the Preview logs](../debug-config-file/#how-to-check-the-preview-logs). The most common cause of build failures
+is when one of the commands in the Tugboat [configuration file](/setting-up-tugboat/create-a-tugboat-config-file/) exits
+with an error. If that is the case, it's time to start [debugging the configuration file](../debug-config-file/).
 
 ![Failed Preview Log](/_images/failed-log.png)
 
-If you're having problems figuring out why the Preview build `failed`, we're
-happy to look into the problem with you to see whether we can help. We've gotten
-good at spotting common config file issues, and we're happy to help.
+If you're having problems figuring out why the Preview build `failed`, we're happy to look into the problem with you to
+see whether we can help. We've gotten good at spotting common config file issues, and we're happy to help.
 [Let us know](https://tugboat.qa/support).
 
 ## Previews are not building automatically
 
-Are you expecting a Preview to build automatically? Only Previews for pull
-requests are built automatically. If Previews are not being built from your PRs,
-check the [Repository Settings](/setting-up-tugboat/select-repo-settings/), and
-make sure "Build Pull Requests Automatically" is enabled.
+Are you expecting a Preview to build automatically? Only Previews for pull requests are built automatically. If Previews
+are not being built from your PRs, check the [Repository Settings](/setting-up-tugboat/select-repo-settings/), and make
+sure "Build Pull Requests Automatically" is enabled.
 
 ![Build Pull Requests Automatically](/_images/pr-probe.png)
 
-{{% notice tip %}} The option to "Build Pull Requests Automatically" only
-appears if you have linked your Tugboat repository with a git provider
-repository via a
-[git provider integration](/setting-up-tugboat/connect-with-your-provider/). If
-you haven't already connected to a git provider, you'll need to
-[set up a git integration](/setting-up-tugboat/connect-with-your-provider/#adding-a-link-to-a-git-provider),
-and then
-[delete the repository](/setting-up-tugboat/select-repo-settings/#delete-the-repository)
-from Tugboat and
-[add it back to your project](/setting-up-tugboat/add-repos-to-the-project/)
-using the git provider integration. {{% /notice %}}
+{{% notice tip %}} The option to "Build Pull Requests Automatically" only appears if you have linked your Tugboat
+repository with a git provider repository via a
+[git provider integration](/setting-up-tugboat/connect-with-your-provider/). If you haven't already connected to a git
+provider, you'll need to
+[set up a git integration](/setting-up-tugboat/connect-with-your-provider/#adding-a-link-to-a-git-provider), and then
+[delete the repository](/setting-up-tugboat/select-repo-settings/#delete-the-repository) from Tugboat and
+[add it back to your project](/setting-up-tugboat/add-repos-to-the-project/) using the git provider integration.
+{{% /notice %}}

--- a/content/tugboat-billing/_index.md
+++ b/content/tugboat-billing/_index.md
@@ -10,7 +10,6 @@ pre = "<b></b>"
 
 # Tugboat Billing
 
-Tugboat pricing, how to change your Tugboat plan and billing information, and
-how to cancel Tugboat billing.
+Tugboat pricing, how to change your Tugboat plan and billing information, and how to cancel Tugboat billing.
 
 {{% children %}}

--- a/content/tugboat-billing/cancel-billing.md
+++ b/content/tugboat-billing/cancel-billing.md
@@ -11,42 +11,35 @@ There are a few ways you can cancel billing for your Tugboat project:
 
 ## Change your Tugboat plan to the Free tier
 
-If you want to downgrade your Tugboat billing, but still keep using Tugboat, you
-can change your Tugboat plan to the Free tier. Follow
-[the instructions to change your Tugboat plan](../change-tugboat-plan/), and
-select the Free tier.
+If you want to downgrade your Tugboat billing, but still keep using Tugboat, you can change your Tugboat plan to the
+Free tier. Follow [the instructions to change your Tugboat plan](../change-tugboat-plan/), and select the Free tier.
 
-{{% notice note %}} If you downgrade your Tugboat plan, the changes will take
-effect when the currently paid cycle is complete. Whenever you view the **Your
-Plan** section of **Project Settings**, you'll see a banner containing the date
+{{% notice note %}} If you downgrade your Tugboat plan, the changes will take effect when the currently paid cycle is
+complete. Whenever you view the **Your Plan** section of **Project Settings**, you'll see a banner containing the date
 that the change will take effect. If your
-[project storage](../tugboat-pricing/#calculating-project-storage-for-tugboat-billing)
-is over the limit of the lower-level tier, you won't be able to build any new
-Previews until you've freed up enough space to put you under that storage limit.
-{{% /notice %}}
+[project storage](../tugboat-pricing/#calculating-project-storage-for-tugboat-billing) is over the limit of the
+lower-level tier, you won't be able to build any new Previews until you've freed up enough space to put you under that
+storage limit. {{% /notice %}}
 
 ## Delete your project
 
-If you don't need your Tugboat Previews anymore, or are finished using Tugboat
-for a particular project, you can always delete your project:
+If you don't need your Tugboat Previews anymore, or are finished using Tugboat for a particular project, you can always
+delete your project:
 
-1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-   upper-right of the Tugboat dashboard.
+1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat dashboard.
 2. Select the project you want to delete.
 3. Go to {{% ui-text %}}Project Settings{{% /ui-text %}}.
 4. Scroll down past {{% ui-text %}}Your Plan{{% /ui-text %}}.
 5. Click the red {{% ui-text %}}Delete Project{{% /ui-text %}} button.
 
-{{% notice note %}} When you delete a Tugboat project, you're only deleting the
-Previews and Tugboat repositories for that project. This does not affect data in
-your git repositories. This also does not affect other Tugboat projects; if you
-have three projects in Tugboat, for example, and you delete one of them, you can
-still continue working in the other two projects. {{% /notice %}}
+{{% notice note %}} When you delete a Tugboat project, you're only deleting the Previews and Tugboat repositories for
+that project. This does not affect data in your git repositories. This also does not affect other Tugboat projects; if
+you have three projects in Tugboat, for example, and you delete one of them, you can still continue working in the other
+two projects. {{% /notice %}}
 
 {{%expand "Visual Walkthrough" %}}
 
-Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-upper-right of the Tugboat dashboard.
+Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat dashboard.
 
 ![Go to username -> My Projects](../../_images/go-to-user-my-projects.png)
 

--- a/content/tugboat-billing/change-billing-information.md
+++ b/content/tugboat-billing/change-billing-information.md
@@ -6,8 +6,7 @@ weight: 3
 
 ## To change the billing information for your Tugboat project:
 
-1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-   upper-right of the Tugboat dashboard.
+1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat dashboard.
 2. Select the project where you want to change the billing info.
 3. Go to {{% ui-text %}}Project Settings{{% /ui-text %}}.
 4. Scroll down to {{% ui-text %}}Your Plan{{% /ui-text %}}.
@@ -21,8 +20,7 @@ From here, you can:
 
 {{%expand "Visual Walkthrough" %}}
 
-Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-upper-right of the Tugboat dashboard.
+Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat dashboard.
 
 ![Go to username -> My Projects](../../_images/go-to-user-my-projects.png)
 

--- a/content/tugboat-billing/change-tugboat-plan.md
+++ b/content/tugboat-billing/change-tugboat-plan.md
@@ -6,30 +6,24 @@ weight: 2
 
 ## To change your Tugboat plan:
 
-1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-   upper-right of the Tugboat dashboard.
+1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat dashboard.
 2. Select the project where you want to change the plan.
 3. Go to {{% ui-text %}}Project Settings{{% /ui-text %}}.
 4. Scroll down to {{% ui-text %}}Your Plan{{% /ui-text %}}.
-5. Click the radio button next to the new plan you want, and hit the
-   {{% ui-text %}}Update Tier{{% /ui-text %}} button.
+5. Click the radio button next to the new plan you want, and hit the {{% ui-text %}}Update Tier{{% /ui-text %}} button.
 
-You'll get info about your new plan, and if you're setting up a paid plan for
-the first time, you'll be prompted to enter your payment information. Fill this
-out, hit the {{% ui-text %}}Update Tier{{% /ui-text %}} button again, and you'll
-be all set to enjoy your new plan.
+You'll get info about your new plan, and if you're setting up a paid plan for the first time, you'll be prompted to
+enter your payment information. Fill this out, hit the {{% ui-text %}}Update Tier{{% /ui-text %}} button again, and
+you'll be all set to enjoy your new plan.
 
-You'll get an email confirming your changes, with a link to an online invoice
-you can download or print as needed.
+You'll get an email confirming your changes, with a link to an online invoice you can download or print as needed.
 
 {{% notice note %}} If you're using Tugboat's enterprise plans,
-[reach out to us directly](mailto:support@tugboat.qa?subject=Enterprise-Plans)
-to change your plan. {{% /notice %}}
+[reach out to us directly](mailto:support@tugboat.qa?subject=Enterprise-Plans) to change your plan. {{% /notice %}}
 
 {{%expand "Visual Walkthrough" %}}
 
-Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-upper-right of the Tugboat dashboard.
+Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat dashboard.
 
 ![Go to username -> My Projects](../../_images/go-to-user-my-projects.png)
 
@@ -45,20 +39,17 @@ Scroll down to {{% ui-text %}}Your Plan{{% /ui-text %}}.
 
 ![Scroll down to Your Plan](../../_images/billing-view-tugboat-plan.png)
 
-Click the radio button next to the new plan you want, and hit the
-{{% ui-text %}}Update Tier{{% /ui-text %}} button.
+Click the radio button next to the new plan you want, and hit the {{% ui-text %}}Update Tier{{% /ui-text %}} button.
 
 ![Change your Tugboat plan tier](../../_images/billing-change-plan-update-tier.png)
 
-You'll get info about your new plan, and if you're setting up a paid plan for
-the first time, you'll be prompted to enter your payment information. Fill this
-out, hit the {{% ui-text %}}Update Tier{{% /ui-text %}} button again, and you'll
-be all set to enjoy your new plan.
+You'll get info about your new plan, and if you're setting up a paid plan for the first time, you'll be prompted to
+enter your payment information. Fill this out, hit the {{% ui-text %}}Update Tier{{% /ui-text %}} button again, and
+you'll be all set to enjoy your new plan.
 
 ![Setting up a paid Tugboat plan](../../_images/billing-setting-up-paid-tugboat-plan.png)
 
-You'll get an email confirming your changes, with a link to an online invoice
-you can download or print as needed.
+You'll get an email confirming your changes, with a link to an online invoice you can download or print as needed.
 
 ![Email confirmation of plan change](../../_images/billing-plan-update-email.png)
 

--- a/content/tugboat-billing/tugboat-pricing.md
+++ b/content/tugboat-billing/tugboat-pricing.md
@@ -12,59 +12,47 @@ weight: 1
 
 ## How does Tugboat pricing work?
 
-Tugboat's pricing isn't based on your account, number of users, or on external
-repositories; Tugboat is priced on a per-project basis.
+Tugboat's pricing isn't based on your account, number of users, or on external repositories; Tugboat is priced on a
+per-project basis.
 
-When you [Create a New Project](/setting-up-tugboat/create-a-new-project/) in
-Tugboat, you'll select a plan based on your
-[Preview storage](#calculating-project-storage-for-tugboat-billing) and
-[build performance](/building-a-preview/preview-deep-dive/optimize-preview-builds/)
-needs. You can then
-[link as many external repositories](/setting-up-tugboat/add-repos-to-the-project/)
-as you'd like to that project, and
-[add as many users](/administer-tugboat-crew/user-admin/#add-a-user-to-a-project)
-as you'd like, all under the same plan.
+When you [Create a New Project](/setting-up-tugboat/create-a-new-project/) in Tugboat, you'll select a plan based on
+your [Preview storage](#calculating-project-storage-for-tugboat-billing) and
+[build performance](/building-a-preview/preview-deep-dive/optimize-preview-builds/) needs. You can then
+[link as many external repositories](/setting-up-tugboat/add-repos-to-the-project/) as you'd like to that project, and
+[add as many users](/administer-tugboat-crew/user-admin/#add-a-user-to-a-project) as you'd like, all under the same
+plan.
 
-If you later find your project doesn't have enough storage, or your Preview
-build performance isn't what you need it to be, you can always
-[change your Tugboat project's performance tier](../change-tugboat-plan/) -
-without affecting your other Tugboat projects.
+If you later find your project doesn't have enough storage, or your Preview build performance isn't what you need it to
+be, you can always [change your Tugboat project's performance tier](../change-tugboat-plan/) - without affecting your
+other Tugboat projects.
 
 ### Calculating Project storage for Tugboat billing
 
-[Project storage](#how-to-view-project-storage) is calculated by adding the size
-of all of the Previews contained in a Tugboat project. This includes any
-[Base Previews](/building-a-preview/work-with-base-previews/set-a-base-preview/),
-as well as additional Previews that have been built from the Base Previews.
-Tugboat calculates Preview sizes across all repositories contained in a project
-when determining project storage, which may be larger than what you see when
-you're viewing an individual repository within Tugboat.
+[Project storage](#how-to-view-project-storage) is calculated by adding the size of all of the Previews contained in a
+Tugboat project. This includes any [Base Previews](/building-a-preview/work-with-base-previews/set-a-base-preview/), as
+well as additional Previews that have been built from the Base Previews. Tugboat calculates Preview sizes across all
+repositories contained in a project when determining project storage, which may be larger than what you see when you're
+viewing an individual repository within Tugboat.
 
 ![Storage in Repository Stats vs. Project Stats](../../_images/billing-repo-stats-vs-project-stats.png)
 
-{{% notice info %}} Curious about why a Preview is larger than your git
-repository? The Preview size is the size of the entire container at the end of
-the Preview build process. If your Preview build is pulling in large assets,
-such as large databases or Service images, your resulting build size includes
-those assets - not only the code from your linked git repo. If you want to
-reduce your Preview size, take a look at our tips in:
-[optimize your Preview builds](/building-a-preview/preview-deep-dive/optimize-preview-builds/).
-{{% /notice %}}
+{{% notice info %}} Curious about why a Preview is larger than your git repository? The Preview size is the size of the
+entire container at the end of the Preview build process. If your Preview build is pulling in large assets, such as
+large databases or Service images, your resulting build size includes those assets - not only the code from your linked
+git repo. If you want to reduce your Preview size, take a look at our tips in:
+[optimize your Preview builds](/building-a-preview/preview-deep-dive/optimize-preview-builds/). {{% /notice %}}
 
 #### How to view project storage
 
-You can view how much storage you've used by going to your Project Dashboard,
-and looking at the Project Stats section:
+You can view how much storage you've used by going to your Project Dashboard, and looking at the Project Stats section:
 
-1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-   upper-right of the Tugboat dashboard.
+1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat dashboard.
 2. Select the project where you want to view disk space used.
 3. Scroll down to {{% ui-text %}}Project Stats{{% /ui-text %}}.
 
 {{%expand "Visual Walkthrough" %}}
 
-Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-upper-right of the Tugboat dashboard.
+Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat dashboard.
 
 ![Go to username -> My Projects](../../_images/go-to-user-my-projects.png)
 
@@ -80,31 +68,25 @@ Scroll down to {{% ui-text %}}Project Stats{{% /ui-text %}}.
 
 ## To view Tugboat pricing for your project:
 
-If you're a current Tugboat user, here's how to view the pricing for your
-project:
+If you're a current Tugboat user, here's how to view the pricing for your project:
 
-1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-   upper-right of the Tugboat dashboard.
+1. Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat dashboard.
 2. Select the project where you want to view and administer billing.
 3. Go to {{% ui-text %}}Project Settings{{% /ui-text %}}.
 4. Scroll down to {{% ui-text %}}Your Plan{{% /ui-text %}}.
 
 From here, you'll see the pricing tiers available for your plan. You can
-[change performance tiers](../change-tugboat-plan/), or
-[Delete the Project](../cancel-billing/#delete-your-project) if you're finished
-using Tugboat for that project.
+[change performance tiers](../change-tugboat-plan/), or [Delete the Project](../cancel-billing/#delete-your-project) if
+you're finished using Tugboat for that project.
 
-If you don't have a Tugboat project, you can view current Tugboat pricing here:
-[Pricing](https://tugboat.qa/pricing/).
+If you don't have a Tugboat project, you can view current Tugboat pricing here: [Pricing](https://tugboat.qa/pricing/).
 
-{{% notice note %}} If you're looking for a self-hosted Tugboat, or an
-enterprise version of the app, see:
+{{% notice note %}} If you're looking for a self-hosted Tugboat, or an enterprise version of the app, see:
 [Tugboat for Enterprise](#tugboat-for-enterprise). {{% /notice %}}
 
 {{%expand "Visual Walkthrough" %}}
 
-Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the
-upper-right of the Tugboat dashboard.
+Go to username -> [My Projects](https://dashboard.tugboat.qa/projects) at the upper-right of the Tugboat dashboard.
 
 ![Go to username -> My Projects](../../_images/go-to-user-my-projects.png)
 
@@ -125,9 +107,8 @@ Scroll down to {{% ui-text %}}Your Plan{{% /ui-text %}}.
 ## Tugboat for Enterprise
 
 If you need an enterprise or self-hosted version of Tugboat, we've got
-[Tugboat for Enterprise](https://tugboat.qa/enterprise/) for you! Tugboat's
-enterprise version comes with significantly more Preview storage and RAM, and
-can be hosted in Tugboat's Cloud or behind your firewall.
+[Tugboat for Enterprise](https://tugboat.qa/enterprise/) for you! Tugboat's enterprise version comes with significantly
+more Preview storage and RAM, and can be hosted in Tugboat's Cloud or behind your firewall.
 
 To view pricing and change your Tugboat enterprise plan,
 [contact us](mailto:support@tugboat.qa?subject=Enterprise-Plans).

--- a/content/tugboat-cli/_index.md
+++ b/content/tugboat-cli/_index.md
@@ -14,7 +14,6 @@ Installing and using Tugboat's CLI.
 
 {{% children %}}
 
-The Tugboat [Command Line Tool](https://dashboard.tugboat.qa/downloads) provides
-access to your Tugboat account from your local command line. It allows you to
-perform all of the operations available through the web interface, as well as
+The Tugboat [Command Line Tool](https://dashboard.tugboat.qa/downloads) provides access to your Tugboat account from
+your local command line. It allows you to perform all of the operations available through the web interface, as well as
 other, more advanced features of Tugboat.

--- a/content/tugboat-cli/install-the-cli.md
+++ b/content/tugboat-cli/install-the-cli.md
@@ -4,13 +4,11 @@ date: 2019-09-19T10:41:37-04:00
 weight: 1
 ---
 
-The Tugboat Command Line Tool is available for Windows, MacOS, and Linux. In all
-three cases, it is a stand-alone binary.
+The Tugboat Command Line Tool is available for Windows, MacOS, and Linux. In all three cases, it is a stand-alone
+binary.
 
-1. Download the CLI from
-   [https://dashboard.tugboat.qa/downloads](https://dashboard.tugboat.qa/downloads).
-2. Copy it to a location that the operating system can find in its execution
-   path.
+1. Download the CLI from [https://dashboard.tugboat.qa/downloads](https://dashboard.tugboat.qa/downloads).
+2. Copy it to a location that the operating system can find in its execution path.
 
 **Operating Systems**
 
@@ -20,13 +18,11 @@ three cases, it is a stand-alone binary.
 
 ### Windows
 
-There is currently no installer included with the Windows version of the Tugboat
-Command Line Tool. You'll either need to execute it from the directory where you
-downloaded it, or copy it to a directory in the system PATH variable.
+There is currently no installer included with the Windows version of the Tugboat Command Line Tool. You'll either need
+to execute it from the directory where you downloaded it, or copy it to a directory in the system PATH variable.
 
-For the latter, create a new folder at `C:\Program Files\Tugboat`, and copy the
-downloaded `tugboat.exe` to that folder. Then, add `C:\Program Files\Tugboat` to
-your system PATH variable. A good article describing how to modify the PATH
+For the latter, create a new folder at `C:\Program Files\Tugboat`, and copy the downloaded `tugboat.exe` to that folder.
+Then, add `C:\Program Files\Tugboat` to your system PATH variable. A good article describing how to modify the PATH
 variable for each version of Windows can be found at
 [https://www.computerhope.com/issues/ch000549.htm](https://www.computerhope.com/issues/ch000549.htm)
 
@@ -40,22 +36,19 @@ tar -zxf tugboat.tar.gz -C /usr/local/bin/
 
 #### MacOS Catalina
 
-With Catalina's enhanced security features, the first time you try to execute a
-CLI command, you'll get a dialog telling you that the Tugboat CLI can't be
-opened:
+With Catalina's enhanced security features, the first time you try to execute a CLI command, you'll get a dialog telling
+you that the Tugboat CLI can't be opened:
 
 ![Tugboat CLI can't be opened](../../_images/tugboat-cli-cant-be-opened.png)
 
-Until we're able to release a signed version of the CLI, here's how to work
-around this issue:
+Until we're able to release a signed version of the CLI, here's how to work around this issue:
 
 1. Go into the Finder, and locate the `tugboat` file.
-2. Control-click or right-click the file, and then choose the **OPEN** option
-   from the drop-down menu.
+2. Control-click or right-click the file, and then choose the **OPEN** option from the drop-down menu.
 3. Press the **Open** button.
 
-This saves the Tugboat CLI as an exception to your security settings. From here,
-you should be able to use it as you normally would.
+This saves the Tugboat CLI as an exception to your security settings. From here, you should be able to use it as you
+normally would.
 
 ### Linux
 

--- a/content/tugboat-cli/set-an-access-token.md
+++ b/content/tugboat-cli/set-an-access-token.md
@@ -4,21 +4,19 @@ date: 2019-09-19T10:41:45-04:00
 weight: 2
 ---
 
-The first time you attempt to access a Tugboat resource in the Command Line
-Interface, you'll be asked for an Access Token.
+The first time you attempt to access a Tugboat resource in the Command Line Interface, you'll be asked for an Access
+Token.
 
 To set an Access Token:
 
 1. In Tugboat's web interface, go to User Name -> Access Tokens, or
    [click this link](https://dashboard.tugboat.qa/access-tokens).
 2. Click the {{% ui-text %}}Generate New Token option{{% /ui-text %}}.
-3. You'll be asked to give the Access Token a description; for example, "Command
-   Line Tool"; enter a description and press the
-   {{% ui-text %}}Generate{{% /ui-text %}} button.
-4. Make sure you save your Access Token somewhere safe, as you won't be able to
-   see it again!
-5. When you run the CLI, and attempt to access a resource, you'll be asked for
-   an Access Token; paste it in and hit `Y` to remember it.
+3. You'll be asked to give the Access Token a description; for example, "Command Line Tool"; enter a description and
+   press the {{% ui-text %}}Generate{{% /ui-text %}} button.
+4. Make sure you save your Access Token somewhere safe, as you won't be able to see it again!
+5. When you run the CLI, and attempt to access a resource, you'll be asked for an Access Token; paste it in and hit `Y`
+   to remember it.
 
 Now you're all set to use the Tugboat Command Line Interface!
 
@@ -33,19 +31,17 @@ Click the {{% ui-text %}}Generate New Token{{% /ui-text %}} option.
 
 ![Click Generate new token](../../_images/generate-new-token.png)
 
-You'll be asked to give the Access Token a description; for example, "Command
-Line Tool"; enter a description and press the
-{{% ui-text %}}Generate{{% /ui-text %}} button.
+You'll be asked to give the Access Token a description; for example, "Command Line Tool"; enter a description and press
+the {{% ui-text %}}Generate{{% /ui-text %}} button.
 
 ![Enter token description and press Generate](../../_images/enter-token-description-and-generate.png)
 
-Make sure you save your Access Token somewhere safe, as you won't be able to see
-it again!
+Make sure you save your Access Token somewhere safe, as you won't be able to see it again!
 
 ![Copy your new Access Token](../../_images/copy-new-access-token.png)
 
-When you run the CLI, and attempt to access a resource, you'll be asked for an
-Access Token; paste it in and hit `Y` to have the CLI remember it.
+When you run the CLI, and attempt to access a resource, you'll be asked for an Access Token; paste it in and hit `Y` to
+have the CLI remember it.
 
 ![Enter the Access Token in the CLI](../../_images/enter-access-token-in-cli.png)
 

--- a/content/tugboat-cli/use-the-cli.md
+++ b/content/tugboat-cli/use-the-cli.md
@@ -6,8 +6,7 @@ weight: 3
 
 ## CLI commands
 
-Run `tugboat help` to see a list of commands you can execute. A few options
-include:
+Run `tugboat help` to see a list of commands you can execute. A few options include:
 
 #### View info
 
@@ -59,8 +58,7 @@ tugboat log 5b04c7d14c3dad00016a2e80
 
 ### View Services logs
 
-To view the logs for a Service with an ID of `5d092b16bd44cb22a498be90` that's
-running in a Preview:
+To view the logs for a Service with an ID of `5d092b16bd44cb22a498be90` that's running in a Preview:
 
 ```sh
 tugboat log 5d092b16bd44cb22a498be90
@@ -70,8 +68,7 @@ tugboat log 5d092b16bd44cb22a498be90
 
 ### Build a new Preview
 
-To build a new Preview from the master branch of a Tugboat Repository with an ID
-of `5b02ed093558930001c04cfa`:
+To build a new Preview from the master branch of a Tugboat Repository with an ID of `5b02ed093558930001c04cfa`:
 
 ```sh
 tugboat create preview master repo=5b02ed093558930001c04cfa
@@ -92,9 +89,8 @@ tugboat delete 5b02ed093558930001c04cfa -f
 
 #### Start a shell on the default Service of a Preview
 
-To start a shell on the
-[default Service](/setting-up-services/how-to-set-up-services/define-a-default-service/)
-of a Preview with an ID of `5b04c7d14c3dad00016a2e80`:
+To start a shell on the [default Service](/setting-up-services/how-to-set-up-services/define-a-default-service/) of a
+Preview with an ID of `5b04c7d14c3dad00016a2e80`:
 
 ```sh
 tugboat shell 5b04c7d14c3dad00016a2e80
@@ -104,27 +100,24 @@ tugboat shell 5b04c7d14c3dad00016a2e80
 
 To start a shell on Service that isn't the default:
 
-1. Start by
-   [viewing the Services of the Preview](#view-the-services-of-a-preview).
+1. Start by [viewing the Services of the Preview](#view-the-services-of-a-preview).
 2. Find the Service where you want to start a shell.
 3. Start the shell using the ID of the specific Service.
 
 {{%expand "Visual Walkthrough" %}}
 
-[View the Services of a Preview](#view-the-services-of-a-preview) via its ID; in
-this case, `5d1a5305216a15d4bf5dcbbb`:
+[View the Services of a Preview](#view-the-services-of-a-preview) via its ID; in this case, `5d1a5305216a15d4bf5dcbbb`:
 
 ```sh
 tugboat ls services preview=5d1a5305216a15d4bf5dcbbb
 ```
 
-Find the Service ID for the Service where you want to start the shell; in this
-case, I want the Service ID for the Service I've named `apache`:
+Find the Service ID for the Service where you want to start the shell; in this case, I want the Service ID for the
+Service I've named `apache`:
 
 ![Find the Service ID](/_images/tugboat-cli-find-service-id.png)
 
-Start the shell using the ID of the specific Service; in this example,
-`5d1a5307216a158a155dcbc3`:
+Start the shell using the ID of the specific Service; in this example, `5d1a5307216a158a155dcbc3`:
 
 ```sh
 tugboat shell 5d1a5307216a158a155dcbc3

--- a/content/visual-diffs/configure-visual-diffs.md
+++ b/content/visual-diffs/configure-visual-diffs.md
@@ -4,11 +4,9 @@ date: 2019-09-26T15:29:49-04:00
 weight: 1
 ---
 
-To configure which pages have Visual Diffs generated, specify the _relative
-URLs_ of the pages in a `visualdiffs` key in the
-[service definition](/setting-up-services/). Each URL can be either a string, or
-a map that overrides the default screenshot options. For more info on exactly
-what you can use in this key, check out:
+To configure which pages have Visual Diffs generated, specify the _relative URLs_ of the pages in a `visualdiffs` key in
+the [service definition](/setting-up-services/). Each URL can be either a string, or a map that overrides the default
+screenshot options. For more info on exactly what you can use in this key, check out:
 [Tugboat Configuration -> visualdiffs](/reference/tugboat-configuration/#visualdiffs).
 
 ```yaml
@@ -27,9 +25,8 @@ services:
         waitUntil: domcontentloaded
 ```
 
-The URL list can also be grouped by
-[service alias](/reference/tugboat-configuration/#aliases), which is convenient
-when aliases have different URL structures
+The URL list can also be grouped by [service alias](/reference/tugboat-configuration/#aliases), which is convenient when
+aliases have different URL structures
 
 ```yaml
 services:
@@ -53,6 +50,5 @@ services:
         - /
 ```
 
-{{% notice tip %}} If you're not running an `apache` service on your Preview,
-but you _are_ running `php`, set up Visual Diffs under the `php` service.
-{{% /notice %}}
+{{% notice tip %}} If you're not running an `apache` service on your Preview, but you _are_ running `php`, set up Visual
+Diffs under the `php` service. {{% /notice %}}

--- a/content/visual-diffs/using-visual-diffs.md
+++ b/content/visual-diffs/using-visual-diffs.md
@@ -4,27 +4,21 @@ date: 2019-09-19T10:32:20-04:00
 weight: 4
 ---
 
-When a Preview is built from a
-[Base Preview](/building-a-preview/work-with-base-previews/set-a-base-preview/),
-Tugboat can generate Visual Diff images to highlight any changes between the
-Base Preview and the new Preview.
+When a Preview is built from a [Base Preview](/building-a-preview/work-with-base-previews/set-a-base-preview/), Tugboat
+can generate Visual Diff images to highlight any changes between the Base Preview and the new Preview.
 
 ![Visual Diff Example](/_images/visualdiff.png)
 
 ## How are Visual Diffs calculated?
 
-Tugboat's Visual Diffs implementation is a pixel-by-pixel comparison of what a
-Preview page looks like. The percent calculation displayed next to the diff is a
-literal calculation of how many pixels have changed in the page from Before to
-After. This makes it a great tool for front-end developers to visually see what
-has changed on the page, and it also helps Q/A, Product and UX spot new feature
-implementation - and also regression bugs.
+Tugboat's Visual Diffs implementation is a pixel-by-pixel comparison of what a Preview page looks like. The percent
+calculation displayed next to the diff is a literal calculation of how many pixels have changed in the page from Before
+to After. This makes it a great tool for front-end developers to visually see what has changed on the page, and it also
+helps Q/A, Product and UX spot new feature implementation - and also regression bugs.
 
 ![Example Visual Diff with page contents moved down](/_images/visual-diffs-page-contents-moved-down.png)
 
-As a result of the way Visual Diffs are calculated, though, when you move
-something at the top of the page that bumps content down, the whole page may
-show up as changed. This is because all of the pixels on the pixel-by-pixel
-calculation are no longer an exact match; everything has shifted down. It's
-great for visual regression testing, or spotting the introduction of new bugs,
-but may make something like diffing content changes visually less meaningful.
+As a result of the way Visual Diffs are calculated, though, when you move something at the top of the page that bumps
+content down, the whole page may show up as changed. This is because all of the pixels on the pixel-by-pixel calculation
+are no longer an exact match; everything has shifted down. It's great for visual regression testing, or spotting the
+introduction of new bugs, but may make something like diffing content changes visually less meaningful.

--- a/content/visual-diffs/view-visual-diffs.md
+++ b/content/visual-diffs/view-visual-diffs.md
@@ -12,21 +12,17 @@ To view Visual Diffs, you'll need to go to the Preview Dashboard.
 2. Scroll down past the Preview Log and you'll see the Visual Diffs pane.
 3. Click into the Visual Diff for Mobile, Tablet or Desktop to see the diff.
 
-Inside the diff, you'll see a **Before** visualization on the left, an **After**
-visualization on the right, and a composite in the middle, which highlights
-changes to the page.
+Inside the diff, you'll see a **Before** visualization on the left, an **After** visualization on the right, and a
+composite in the middle, which highlights changes to the page.
 
-You'll also see an option to {{% ui-text %}}Regenerate{{% /ui-text %}} visual
-diffs; use this if you've updated your Base Preview, and want to see a new
-version of the visual diffs for this build.
+You'll also see an option to {{% ui-text %}}Regenerate{{% /ui-text %}} visual diffs; use this if you've updated your
+Base Preview, and want to see a new version of the visual diffs for this build.
 
-{{% notice info %}} While the Preview is building, you'll see: "Unavailable
-while preview is building" in the Visual Diffs pane. After the Preview build has
-completed, it will take some time for visual diffs to generate. If you get an
-error message, or don't see what you expect when the visual diffs generate, head
-over to
-[Troubleshooting -> Visual Diffs](/troubleshooting/preview-built-problem/#troubleshooting-visual-diffs)
-for tips on figuring out what happened. {{% /notice %}}
+{{% notice info %}} While the Preview is building, you'll see: "Unavailable while preview is building" in the Visual
+Diffs pane. After the Preview build has completed, it will take some time for visual diffs to generate. If you get an
+error message, or don't see what you expect when the visual diffs generate, head over to
+[Troubleshooting -> Visual Diffs](/troubleshooting/preview-built-problem/#troubleshooting-visual-diffs) for tips on
+figuring out what happened. {{% /notice %}}
 
 {{%expand "Visual Walkthrough" %}}
 
@@ -38,20 +34,17 @@ Scroll down past the Preview Log, and you'll see the Visual Diffs pane;
 
 ![View Visual Diffs Pane](/_images/visual-diffs-scroll-to-view-visual-diffs.png)
 
-Click into the Visual Diff for **Mobile**, **Tablet** or **Desktop** to see the
-diff.
+Click into the Visual Diff for **Mobile**, **Tablet** or **Desktop** to see the diff.
 
 ![Click into the Visual Diff to see the diff](/_images/visual-diffs-click-into-mobile-to-view-diff.png)
 
-Inside the diff, you'll see a **Before** visualization on the left, an **After**
-visualization on the right, and a composite in the middle, which highlights
-changes to the page.
+Inside the diff, you'll see a **Before** visualization on the left, an **After** visualization on the right, and a
+composite in the middle, which highlights changes to the page.
 
 ![Visual Diff Before, After and Difference](/_images/visual-diffs-before-after-example.png)
 
-You'll also see an option to {{% ui-text %}}Regenerate{{% /ui-text %}} visual
-diffs; use this if you've updated your Base Preview, and want to see a new
-version of the visual diffs for this build.
+You'll also see an option to {{% ui-text %}}Regenerate{{% /ui-text %}} visual diffs; use this if you've updated your
+Base Preview, and want to see a new version of the visual diffs for this build.
 
 ![Regenerate visual diffs](/_images/visual-diffs-regenerate.png)
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "broken-link-checker-local": "^0.2.0",
-    "prettier": "^1.18.2"
+    "prettier": "^1.19.1"
   },
   "prettier": {
     "printWidth": 80,

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "prettier": "^1.19.1"
   },
   "prettier": {
-    "printWidth": 80,
+    "printWidth": 120,
     "proseWrap": "always"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -885,10 +885,10 @@ path-to-regexp@0.1.7:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
 
-prettier@^1.18.2:
-  version "1.18.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
-  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
+prettier@^1.19.1:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
+  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
 process-nextick-args@~2.0.0:
   version "2.0.1"


### PR DESCRIPTION
* Upgrade prettier to latest version
* Change the prettier config to wrap lines at 120 characters instead of 80

This is kind of a backwards workaround to a markdown parsing problem in hugo for a particular line that broke at 80 characters in such a way that it created an unexpected `<p>` tag. But, 120 characters seems more reasonable at today's screen sizes anyway.