### PR TITLE
Fixes syntax errors in Drupal 8 example

### DIFF
--- a/content/starter-configs/tutorials/drupal-8.md
+++ b/content/starter-configs/tutorials/drupal-8.md
@@ -86,8 +86,8 @@ services:
         # project, you can either specify the absolute paths to those
         # directories in your settings.local.php, or you can symlink them in
         # here. Here is an example of the latter option:
-        - ln -snf "${TUGBOAT_ROOT/config" "${DOCROOT}/../config"
-        - ln -snf "${TUGBOAT_ROOT/files-private" "${DOCROOT}/../files-private"
+        - ln -snf "${TUGBOAT_ROOT}/config" "${DOCROOT}/../config"
+        - ln -snf "${TUGBOAT_ROOT}/files-private" "${DOCROOT}/../files-private"
 
       # Commands that import files, databases,  or other assets. When an
       # existing preview is refreshed, the build workflow starts here,


### PR DESCRIPTION
Found what appears to be a syntax error in the examples for Drupal 8.