### PR TITLE
Add other Tugboat properties to GA tracking

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -44,8 +44,7 @@
 
     {{ partial "configurable_twitter_cards.html" . }}
 
-
-    {{ template "_internal/google_analytics.html" . }}
+    {{ partial "new-google-analytics.html" . }}
 
   </head>
   <body class="" data-url="{{ .RelPermalink }}">

--- a/layouts/partials/new-google-analytics.html
+++ b/layouts/partials/new-google-analytics.html
@@ -13,8 +13,11 @@ if (!doNotTrack) {
 		var GA_SESSION_STORAGE_KEY = 'ga:clientId';
 		ga('create', '{{ . }}', {
 	    'storage': 'none',
-	    'clientId': sessionStorage.getItem(GA_SESSION_STORAGE_KEY)
+	    'clientId': sessionStorage.getItem(GA_SESSION_STORAGE_KEY),
+	    'allowLinker': true
 	   });
+	   ga('require', 'linker');
+	   ga('linker:autoLink', ['tugboat.qa', 'dashboard.tugboat.qa', 'api.tugboat.qa'] );
 	   ga(function(tracker) {
 	    sessionStorage.setItem(GA_SESSION_STORAGE_KEY, tracker.get('clientId'));
 	   });

--- a/layouts/partials/new-google-analytics.html
+++ b/layouts/partials/new-google-analytics.html
@@ -17,7 +17,7 @@ if (!doNotTrack) {
 	    'allowLinker': true
 	   });
 	   ga('require', 'linker');
-	   ga('linker:autoLink', ['tugboat.qa', 'dashboard.tugboat.qa', 'api.tugboat.qa'] );
+	   ga('linker:autoLink', ['www.tugboat.qa', 'dashboard.tugboat.qa', 'preview.tugboat.qa', 'api.tugboat.qa'] );
 	   ga(function(tracker) {
 	    sessionStorage.setItem(GA_SESSION_STORAGE_KEY, tracker.get('clientId'));
 	   });
@@ -25,7 +25,7 @@ if (!doNotTrack) {
 	{{ else }}
 	ga('create', '{{ . }}', 'auto', {'allowLinker': true});
   	ga('require', 'linker');
-  	ga('linker:autoLink', ['tugboat.qa', 'dashboard.tugboat.qa', 'api.tugboat.qa'] );
+  	ga('linker:autoLink', ['www.tugboat.qa', 'dashboard.tugboat.qa', 'preview.tugboat.qa', 'api.tugboat.qa'] );
 	{{ end -}}
 	{{ if $pc.AnonymizeIP }}ga('set', 'anonymizeIp', true);{{ end }}
 	ga('send', 'pageview');

--- a/layouts/partials/new-google-analytics.html
+++ b/layouts/partials/new-google-analytics.html
@@ -1,0 +1,41 @@
+{{- $pc := .Site.Config.Privacy.GoogleAnalytics -}}
+{{- if not $pc.Disable -}}
+{{ with .Site.GoogleAnalytics }}
+<script type="application/javascript">
+{{ template "__ga_js_set_doNotTrack" $ }}
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	{{- if $pc.UseSessionStorage }}
+	if (window.sessionStorage) {
+		var GA_SESSION_STORAGE_KEY = 'ga:clientId';
+		ga('create', '{{ . }}', {
+	    'storage': 'none',
+	    'clientId': sessionStorage.getItem(GA_SESSION_STORAGE_KEY)
+	   });
+	   ga(function(tracker) {
+	    sessionStorage.setItem(GA_SESSION_STORAGE_KEY, tracker.get('clientId'));
+	   });
+   }
+	{{ else }}
+	ga('create', '{{ . }}', 'auto', {'allowLinker': true});
+  ga('require', 'linker');
+  ga('linker:autoLink', ['tugboat.qa', 'dashboard.tugboat.qa', 'api.tugboat.qa'] );
+	{{ end -}}
+	{{ if $pc.AnonymizeIP }}ga('set', 'anonymizeIp', true);{{ end }}
+	ga('send', 'pageview');
+}
+</script>
+{{ end }}
+{{- end -}}
+{{- define "__ga_js_set_doNotTrack" -}}{{/* This is also used in the async version. */}}
+{{- $pc := .Site.Config.Privacy.GoogleAnalytics -}}
+{{- if not $pc.RespectDoNotTrack -}}
+var doNotTrack = false;
+{{- else -}}
+var dnt = (navigator.doNotTrack || window.doNotTrack || navigator.msDoNotTrack);
+var doNotTrack = (dnt == "1" || dnt == "yes");
+{{- end -}}
+{{- end -}}

--- a/layouts/partials/new-google-analytics.html
+++ b/layouts/partials/new-google-analytics.html
@@ -21,8 +21,8 @@ if (!doNotTrack) {
    }
 	{{ else }}
 	ga('create', '{{ . }}', 'auto', {'allowLinker': true});
-  ga('require', 'linker');
-  ga('linker:autoLink', ['tugboat.qa', 'dashboard.tugboat.qa', 'api.tugboat.qa'] );
+  	ga('require', 'linker');
+  	ga('linker:autoLink', ['tugboat.qa', 'dashboard.tugboat.qa', 'api.tugboat.qa'] );
 	{{ end -}}
 	{{ if $pc.AnonymizeIP }}ga('set', 'anonymizeIp', true);{{ end }}
 	ga('send', 'pageview');


### PR DESCRIPTION
Couldn't figure out where the template stuff is generated in Hugo in order to modify it, so I switched the template to a `partial`, and created a new `partial`, used the official Hugo template file from the gohugo project here to generate the partial: https://github.com/gohugoio/hugo/blob/master/tpl/tplimpl/embedded/templates/google_analytics.html

From here, I modified what the partial should generate to match the Google Analytics help article for cross-property tracking: https://support.google.com/analytics/answer/1034342?hl=en

Once we get these GA updates configured on all of Tugboat's properties, we should be able to track traffic/conversions across properties. 