### PR TITLE
Change `master` branch references to `main` branch

### DIFF
--- a/content/faq/find-tugboat-ids.md
+++ b/content/faq/find-tugboat-ids.md
@@ -249,16 +249,16 @@ You'll see a response similar to this:
 
          Preview ID                 OPTS     Status       Size      Name
          ------------------------  --------  -----------  --------  ---------------------
-         5dfic54972db400001b8d290    ⚓️ ☾️     ready        622.72MB  master
-           https://master-5vt12vtfuqy0chpzdhernpafabmixrny.tugboat.qa
+         5dfic54972db400001b8d290    ⚓️ ☾️     ready        622.72MB  main
+           https://main-5vt12vtfuqy0chpzdhernpafabmixrny.tugboat.qa
 
    Project: 5mdkso12376f987ckif01f10 - Company ABC Documentation Site
       Repository: 5mdkso12376f987ckif0c3dd - CompanyABC/documentation-site
 
           Preview ID                 OPTS     Status       Size      Name
           ------------------------  --------  -----------  --------  ---------------------
-          5d3750bee9b02644d56b0a89    ⚓️ ☾️     ready         435.9MB  master
-            https://master-kkmsgw224wtjtlbqviabxqitakcfvrdv.tugboat.qa
+          5d3750bee9b02644d56b0a89    ⚓️ ☾️     ready         435.9MB  main
+            https://main-kkmsgw224wtjtlbqviabxqitakcfvrdv.tugboat.qa
 ```
 
 ##### List the Previews in a specific project
@@ -277,15 +277,15 @@ You'll see a response similar to this:
 
          Preview ID                 OPTS     Status       Size      Name
          ------------------------  --------  -----------  --------  ---------------------
-         5dfic54972db400001b8d290    ⚓️ ☾️     ready        622.72MB  master
-           https://master-5vt12vtfuqy0chpzdhernpafabmixrny.tugboat.qa
+         5dfic54972db400001b8d290    ⚓️ ☾️     ready        622.72MB  main
+           https://main-5vt12vtfuqy0chpzdhernpafabmixrny.tugboat.qa
 
       Repository: 5dfic6be53my123401b8df5d - CompanyABC/marketing-assets
 
          Preview ID                 OPTS     Status       Size      Name
          ------------------------  --------  -----------  --------  ---------------------
-         5dfic0761394630860890c88    ⚓️ ☾️     ready        554.15MB  master
-           https://master-eza4ulhhdmye7lixxpqjvhn6toduj4qg.tugboat.qa
+         5dfic0761394630860890c88    ⚓️ ☾️     ready        554.15MB  main
+           https://main-eza4ulhhdmye7lixxpqjvhn6toduj4qg.tugboat.qa
 ```
 
 ##### List the Previews in a specific repository
@@ -304,8 +304,8 @@ You'll see a response similar to this:
 
          Preview ID                 OPTS     Status       Size      Name
          ------------------------  --------  -----------  --------  ---------------------
-         5d3750bee9b02644d56b0a89    ⚓️ ☾️     ready         435.9MB  master
-           https://master-kmyugw294wtjtlbqviabxqinwecfvrdv.tugboat.qa
+         5d3750bee9b02644d56b0a89    ⚓️ ☾️     ready         435.9MB  main
+           https://main-kmyugw294wtjtlbqviabxqinwecfvrdv.tugboat.qa
 
          5d8a44a86ada2349d59d309e      ☾️     failed             0B  readme change
            undefined
@@ -324,19 +324,19 @@ You'll see a response similar to this:
 ```sh
    Project: 5dfic23e53my123401b8d0e5 - Company ABC Marketing Site
       Repository: 5dfic23e53my123401b8d0e7 - CompanyABC/marketing
-         Preview: 5dfic54972db400001b8d290 - master
+         Preview: 5dfic54972db400001b8d290 - main
 
             Service ID                State        Size      Name
             ------------------------  -----------  --------  -------------------------------
             5e3b45fa9366b18e6412206a  suspended    413.94MB  companyabc-redis
-              https://master-mj9lot9hdvlbf1ztqw2zsmdhbasge0i5.tugboat.qa
+              https://main-mj9lot9hdvlbf1ztqw2zsmdhbasge0i5.tugboat.qa
 
             5e3b45fa9366b18b8612206c  suspended    1.58GB    companyabc-mongo
-              https://master-siza3cf9u5pc5u9qnba3ukd0s63djski.tugboat.qa
+              https://main-siza3cf9u5pc5u9qnba3ukd0s63djski.tugboat.qa
 
             5e3b45fa9366b1583412206e  suspended    1.81GB    companyabc-ui
-              https://preview.tugboat.qa/master-9a7qh5wgc5w2n738andbu9hlobe8xmdk
+              https://preview.tugboat.qa/main-9a7qh5wgc5w2n738andbu9hlobe8xmdk
 
             5e3b45fa9366b1579f122070  suspended    501.52MB  companyabc-api
-              https://master-amduoolpi4kaldvbrvamdkobnvwcbn8m.tugboat.qa
+              https://main-amduoolpi4kaldvbrvamdkobnvwcbn8m.tugboat.qa
 ```

--- a/content/reference/tugboat-images.md
+++ b/content/reference/tugboat-images.md
@@ -20,27 +20,27 @@ of memcached you use, and you can be sure you always have the most recent versio
 `tugboatqa/memcached` or `tugboatqa/memcached:latest`. See also:
 [Image version tags](/setting-up-services/service-images/image-version-tags/)
 
-| Image                             | Usage                                  |                                                                                              |
-| :-------------------------------- | :------------------------------------- | -------------------------------------------------------------------------------------------- |
-| [Alpine](#alpine)                 | `image: tugboatqa/alpine:[TAG]`        | [Supported Tags](https://github.com/TugboatQA/dockerfiles/blob/master/alpine/TAGS.md)        |
-| Apache                            | `image: tugboatqa/httpd:[TAG]`         | [Supported Tags](https://github.com/TugboatQA/dockerfiles/blob/master/httpd/TAGS.md)         |
-| CentOS                            | `image: tugboatqa/centos:[TAG]`        | [Supported Tags](https://github.com/TugboatQA/dockerfiles/blob/master/centos/TAGS.md)        |
-| CouchDB                           | `image: tugboatqa/couchdb:[TAG]`       | [Supported Tags](https://github.com/TugboatQA/dockerfiles/blob/master/couchdb/TAGS.md)       |
-| Debian                            | `image: tugboatqa/debian:[TAG]`        | [Supported Tags](https://github.com/TugboatQA/dockerfiles/blob/master/debian/TAGS.md)        |
-| [Elastic Search](#elastic-search) | `image: tugboatqa/elasticsearch:[TAG]` | [Supported Tags](https://github.com/TugboatQA/dockerfiles/blob/master/elasticsearch/TAGS.md) |
-| [MariaDB](#mysqlmariadbpercona)   | `image: tugboatqa/mariadb:[TAG]`       | [Supported Tags](https://github.com/TugboatQA/dockerfiles/blob/master/mariadb/TAGS.md)       |
-| Memcached                         | `image: tugboatqa/memcached:[TAG]`     | [Supported Tags](https://github.com/TugboatQA/dockerfiles/blob/master/memcached/TAGS.md)     |
-| MongoDB                           | `image: tugboatqa/mongo:[TAG]`         | [Supported Tags](https://github.com/TugboatQA/dockerfiles/blob/master/mongo/TAGS.md)         |
-| [MySQL](#mysqlmariadbpercona)     | `image: tugboatqa/mysql:[TAG]`         | [Supported Tags](https://github.com/TugboatQA/dockerfiles/blob/master/mysql/TAGS.md)         |
-| Nginx                             | `image: tugboatqa/nginx:[TAG]`         | [Supported Tags](https://github.com/TugboatQA/dockerfiles/blob/master/nginx/TAGS.md)         |
-| Node                              | `image: tugboatqa/node:[TAG]`          | [Supported Tags](https://github.com/TugboatQA/dockerfiles/blob/master/node/TAGS.md)          |
-| [Percona](#mysqlmariadbpercona)   | `image: tugboatqa/percona:[TAG]`       | [Supported Tags](https://github.com/TugboatQA/dockerfiles/blob/master/percona/TAGS.md)       |
-| [PHP](#php)                       | `image: tugboatqa/php:[TAG]`           | [Supported Tags](https://github.com/TugboatQA/dockerfiles/blob/master/php/TAGS.md)           |
-| PostgreSQL                        | `image: tugboatqa/postgres:[TAG]`      | [Supported Tags](https://github.com/TugboatQA/dockerfiles/blob/master/postgres/TAGS.md)      |
-| Redis                             | `image: tugboatqa/redis:[TAG]`         | [Supported Tags](https://github.com/TugboatQA/dockerfiles/blob/master/redis/TAGS.md)         |
-| Solr                              | `image: tugboatqa/solr:[TAG]`          | [Supported Tags](https://github.com/TugboatQA/dockerfiles/blob/master/solr/TAGS.md)          |
-| Ubuntu                            | `image: tugboatqa/ubuntu:[TAG]`        | [Supported Tags](https://github.com/TugboatQA/dockerfiles/blob/master/ubuntu/TAGS.md)        |
-| Varnish                           | `image: tugboatqa/varnish:[TAG]`       | [Supported Tags](https://github.com/TugboatQA/dockerfiles/blob/master/varnish/TAGS.md)       |
+| Image                             | Usage                                  |                                                                                            |
+| :-------------------------------- | :------------------------------------- | ------------------------------------------------------------------------------------------ |
+| [Alpine](#alpine)                 | `image: tugboatqa/alpine:[TAG]`        | [Supported Tags](https://github.com/TugboatQA/dockerfiles/blob/main/alpine/TAGS.md)        |
+| Apache                            | `image: tugboatqa/httpd:[TAG]`         | [Supported Tags](https://github.com/TugboatQA/dockerfiles/blob/main/httpd/TAGS.md)         |
+| CentOS                            | `image: tugboatqa/centos:[TAG]`        | [Supported Tags](https://github.com/TugboatQA/dockerfiles/blob/main/centos/TAGS.md)        |
+| CouchDB                           | `image: tugboatqa/couchdb:[TAG]`       | [Supported Tags](https://github.com/TugboatQA/dockerfiles/blob/main/couchdb/TAGS.md)       |
+| Debian                            | `image: tugboatqa/debian:[TAG]`        | [Supported Tags](https://github.com/TugboatQA/dockerfiles/blob/main/debian/TAGS.md)        |
+| [Elastic Search](#elastic-search) | `image: tugboatqa/elasticsearch:[TAG]` | [Supported Tags](https://github.com/TugboatQA/dockerfiles/blob/main/elasticsearch/TAGS.md) |
+| [MariaDB](#mysqlmariadbpercona)   | `image: tugboatqa/mariadb:[TAG]`       | [Supported Tags](https://github.com/TugboatQA/dockerfiles/blob/main/mariadb/TAGS.md)       |
+| Memcached                         | `image: tugboatqa/memcached:[TAG]`     | [Supported Tags](https://github.com/TugboatQA/dockerfiles/blob/main/memcached/TAGS.md)     |
+| MongoDB                           | `image: tugboatqa/mongo:[TAG]`         | [Supported Tags](https://github.com/TugboatQA/dockerfiles/blob/main/mongo/TAGS.md)         |
+| [MySQL](#mysqlmariadbpercona)     | `image: tugboatqa/mysql:[TAG]`         | [Supported Tags](https://github.com/TugboatQA/dockerfiles/blob/main/mysql/TAGS.md)         |
+| Nginx                             | `image: tugboatqa/nginx:[TAG]`         | [Supported Tags](https://github.com/TugboatQA/dockerfiles/blob/main/nginx/TAGS.md)         |
+| Node                              | `image: tugboatqa/node:[TAG]`          | [Supported Tags](https://github.com/TugboatQA/dockerfiles/blob/main/node/TAGS.md)          |
+| [Percona](#mysqlmariadbpercona)   | `image: tugboatqa/percona:[TAG]`       | [Supported Tags](https://github.com/TugboatQA/dockerfiles/blob/main/percona/TAGS.md)       |
+| [PHP](#php)                       | `image: tugboatqa/php:[TAG]`           | [Supported Tags](https://github.com/TugboatQA/dockerfiles/blob/main/php/TAGS.md)           |
+| PostgreSQL                        | `image: tugboatqa/postgres:[TAG]`      | [Supported Tags](https://github.com/TugboatQA/dockerfiles/blob/main/postgres/TAGS.md)      |
+| Redis                             | `image: tugboatqa/redis:[TAG]`         | [Supported Tags](https://github.com/TugboatQA/dockerfiles/blob/main/redis/TAGS.md)         |
+| Solr                              | `image: tugboatqa/solr:[TAG]`          | [Supported Tags](https://github.com/TugboatQA/dockerfiles/blob/main/solr/TAGS.md)          |
+| Ubuntu                            | `image: tugboatqa/ubuntu:[TAG]`        | [Supported Tags](https://github.com/TugboatQA/dockerfiles/blob/main/ubuntu/TAGS.md)        |
+| Varnish                           | `image: tugboatqa/varnish:[TAG]`       | [Supported Tags](https://github.com/TugboatQA/dockerfiles/blob/main/varnish/TAGS.md)       |
 
 ---
 

--- a/content/setting-up-services/how-to-set-up-services/specify-a-service-image.md
+++ b/content/setting-up-services/how-to-set-up-services/specify-a-service-image.md
@@ -53,7 +53,7 @@ To dissect the key value in our Apache image key example above, we're calling:
 [Apache HTTP Server](https://hub.docker.com/r/tugboatqa/httpd).  
 `2.4` : **OPTIONAL** version tag; in this case, we're calling for the specific 2.4 version of Tugboat's Apache HTTP
 server image. If you browse to the
-[supported images in our GitHub repo](https://github.com/TugboatQA/dockerfiles/blob/master/httpd/TAGS.md), you can see a
+[supported images in our GitHub repo](https://github.com/TugboatQA/dockerfiles/blob/main/httpd/TAGS.md), you can see a
 list of all the version tags available for Tugboat's Apache HTTP Server image.
 
 For more on version tags, take a look at our

--- a/content/tugboat-cli/use-the-cli.md
+++ b/content/tugboat-cli/use-the-cli.md
@@ -68,10 +68,10 @@ tugboat log 5d092b16bd44cb22a498be90
 
 ### Build a new Preview
 
-To build a new Preview from the master branch of a Tugboat Repository with an ID of `5b02ed093558930001c04cfa`:
+To build a new Preview from the `main` branch of a Tugboat Repository with an ID of `5b02ed093558930001c04cfa`:
 
 ```sh
-tugboat create preview master repo=5b02ed093558930001c04cfa
+tugboat create preview main repo=5b02ed093558930001c04cfa
 ```
 
 ### Delete a Preview


### PR DESCRIPTION
There are two references I can't change because they rely on external services to change their branch names (Pantheon: https://pantheon.io/docs/terminus/install#terminus-installer-phar     and     PHP/Docker: https://github.com/docker-library/docs/blob/master/php/README.md#how-to-install-more-php-extensions ). There are also some references within the Hugo Learn theme, as it's the base branch used all over within the theme.

I think this may be the best we can do for the moment.