### PR TITLE
Create custom notice shortcode styling for premium tier features

### DIFF
--- a/themes/hugo-theme-learn/static/css/theme.css
+++ b/themes/hugo-theme-learn/static/css/theme.css
@@ -535,6 +535,13 @@ div.notices.tip p {
 div.notices.tip p:first-child:after {
     content: 'Tip';
 }
+div.notices.tier p {
+    border-top: 30px solid #8F269E;
+    background: #F1D6F5;
+}
+div.notices.tier p:first-child:after {
+    content: 'Premium Tier Feature';
+}
 
 /* attachments shortcode */
 


### PR DESCRIPTION
Made a new style for a "Premium Tier Feature" callout (referred to as a "notice" shortcode in this Hugo theme). 

My instinct says this should live in a custom .css somewhere instead of just appending it to the theme's .css, in the event that we ever update the theme and accidentally blow away this custom style. But I couldn't quickly figure out where that should be - i.e. where Hugo would know to look for it - and didn't want to spend too much time on this.

If we want to merge this, I can then use this notice style to add a note to the "Preview IP Filtering" feature we're documenting in #210 and denote that it's an enterprise-only feature.

I did validate that it works locally - here's what it looks like:

<img width="917" alt="Screen Shot 2020-06-30 at 2 26 23 PM" src="https://user-images.githubusercontent.com/1308377/86163033-b2e34900-badd-11ea-8857-c0ec7a72c7dc.png">
