### PR TITLE
Create Drupal 9 tutorial page

### DIFF
--- a/content/starter-configs/tutorials/drupal-8.md
+++ b/content/starter-configs/tutorials/drupal-8.md
@@ -1,7 +1,7 @@
 ---
 title: "Drupal 8"
 date: 2019-09-19T10:59:21-04:00
-weight: 2
+weight: 1
 ---
 
 Wondering how to configure Tugboat for a typical Drupal 8 repository? Every Drupal site tends to have slightly different

--- a/content/starter-configs/tutorials/drupal-9.md
+++ b/content/starter-configs/tutorials/drupal-9.md
@@ -1,62 +1,59 @@
 ---
-title: "Drupal 7"
-date: 2019-09-19T10:59:15-04:00
-weight: 2
+title: "Drupal 9"
+date: 2020-07-06T10:00:00-04:00
+weight: 0.5
 ---
 
-Wondering how to configure Tugboat for a typical Drupal 7 repository? Every Drupal site tends to have slightly different
-requirements, so you may need to do more customizing, but this should get you started.
+Every Drupal 9 site has its own requirements, so you'll need to add details specific to your configuration, but this
+tutorial should get you started.
 
 ## Configure Drupal
 
-A common practice for managing Drupal's `settings.php` is to remove sensitive information, such as database credentials,
-before committing it to git. Then, the sensitive information is loaded from a `settings.local.php` file that exists only
-on the Drupal installation location.
+A common practice for managing Drupal's `settings.php` is to leave sensitive information, such as database credentials,
+out of it and commit it to git. Then, the sensitive information is loaded from a `settings.local.php` file that exists
+only on the Drupal installation location.
 
-This pattern works very well with Tugboat. It lets you keep a Tugboat-specific set of configurations in your repository
-where it can be copied in during the
-[Preview build process](/building-a-preview/preview-deep-dive/how-previews-work/#the-build-process-explained).
+This pattern works very well with Tugboat. It lets you keep a Tugboat-specific set of configurations in your repository,
+where you can copy it into place with a
+[configuration file command](/setting-up-services/how-to-set-up-services/leverage-service-commands/).
 
-Add the following to the end of `settings.php`:
+Add or uncomment the following at the end of `settings.php`
 
 ```php
-if (file_exists(DRUPAL_ROOT . '/' . conf_path() . '/settings.local.php')) {
-  include DRUPAL_ROOT . '/' . conf_path() . '/settings.local.php';
+if (file_exists($app_root . '/' . $site_path . '/settings.local.php')) {
+  include $app_root . '/' . $site_path . '/settings.local.php';
 }
 ```
 
 Add a file to the git repository at `.tugboat/settings.local.php` with the following content:
 
 ```php
-<?php
-$databases = array (
-  'default' =>
-  array (
-    'default' =>
-    array (
-      'database' => 'tugboat',
-      'username' => 'tugboat',
-      'password' => 'tugboat',
-      'host' => 'mysql',
-      'port' => '',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
+$databases['default']['default'] = array (
+  'database' => 'tugboat',
+  'username' => 'tugboat',
+  'password' => 'tugboat',
+  'prefix' => '',
+  'host' => 'mysql',
+  'port' => '3306',
+  'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
+  'driver' => 'mysql',
 );
+// Use the TUGBOAT_REPO_ID to generate a hash salt for Tugboat sites.
+$settings['hash_salt'] = hash('sha256', getenv('TUGBOAT_REPO_ID'));
 ```
 
 ## Configure Tugboat
 
 The Tugboat configuration is managed by a [YAML file](/setting-up-tugboat/create-a-tugboat-config-file/) at
-`.tugboat/config.yml` in the git repository. Here's a basic Drupal 7 configuration you can use as a starting point, with
+`.tugboat/config.yml` in the git repository. Here's a basic Drupal 8 configuration you can use as a starting point, with
 comments to explain what's going on:
 
 ```yaml
 services:
+  # What to call the service hosting the site.
   php:
-    # Use PHP 7.1 with Apache to serve the Drupal site
-    image: tugboatqa/php:7.1-apache
+    # Use PHP 7.x with Apache; this syntax pulls in the latest version of PHP 7
+    image: tugboatqa/php:7-apache
 
     # Set this as the default service. This does a few things
     #   1. Clones the git repository into the service container
@@ -71,28 +68,39 @@ services:
     commands:
       # Commands that set up the basic preview infrastructure
       init:
-        # Install opcache and enable mod-rewrite.
+        # Install opcache and mod-rewrite.
         - docker-php-ext-install opcache
         - a2enmod headers rewrite
 
-        # Install drush 8.1.17
-        - composer --no-ansi global require drush/drush:8.1.17
-        - ln -sf ~/.composer/vendor/bin/drush /usr/local/bin/drush
+        # Install drush-launcher, if desired.
+        - wget -O /usr/local/bin/drush https://github.com/drush-ops/drush-launcher/releases/download/0.6.0/drush.phar
+        - chmod +x /usr/local/bin/drush
 
-        # Link the document root to the expected path. This example links
-        # /docroot to the docroot
-        - ln -snf "${TUGBOAT_ROOT}/docroot" "${DOCROOT}"
+        # Link the document root to the expected path. This example links /web
+        # to the docroot.
+        - ln -snf "${TUGBOAT_ROOT}/web" "${DOCROOT}"
+
+        # A common practice in many Drupal projects is to store the config and
+        # private files outside of the Drupal root. If that's the case for your
+        # project, you can either specify the absolute paths to those
+        # directories in your settings.local.php, or you can symlink them in
+        # here. Here is an example of the latter option:
+        - ln -snf "${TUGBOAT_ROOT}/config" "${DOCROOT}/../config"
+        - ln -snf "${TUGBOAT_ROOT}/files-private" "${DOCROOT}/../files-private"
 
       # Commands that import files, databases,  or other assets. When an
       # existing preview is refreshed, the build workflow starts here,
       # skipping the init step, because the results of that step will
       # already be present.
       update:
-        # Use the tugboat-specific Drupal settings
+        # Use the tugboat-specific Drupal settings.
         - cp "${TUGBOAT_ROOT}/.tugboat/settings.local.php" "${DOCROOT}/sites/default/"
 
-        # Copy the files directory from an external server. The public
-        # SSH key found in the Tugboat Repository configuration must be
+        # Install/update packages managed by composer, including drush.
+        - composer install --optimize-autoloader
+
+        # Copy Drupal's public files directory from an external server. The
+        # public SSH key found in the Tugboat Repository configuration must be
         # copied to the external server in order to use rsync over SSH.
         - rsync -av --delete user@example.com:/path/to/files/ "${DOCROOT}/sites/default/files/"
 
@@ -101,9 +109,9 @@ services:
         # files from another publicly-accessible Drupal site instead of
         # syncing the entire files directory into the Tugboat Preview.
         # This results in smaller previews and reduces the build time.
-        - drush -r "${DOCROOT}" pm-download stage_file_proxy
-        - drush -r "${DOCROOT}" pm-enable --yes stage_file_proxy
-        - drush -r "${DOCROOT}" variable-set stage_file_proxy_origin "http://www.example.com"
+        - composer require --dev drupal/stage_file_proxy
+        - drush pm:enable --yes stage_file_proxy
+        - drush config:set --yes stage_file_proxy.settings origin "http://www.example.com"
 
         # Set file permissions such that Drupal will not complain
         - chgrp -R www-data "${DOCROOT}/sites/default/files"
@@ -117,11 +125,21 @@ services:
       # and update steps, because the results of those are inherited
       # from the base preview.
       build:
-        - drush -r "${DOCROOT}" cache-clear all
-        - drush -r "${DOCROOT}" updb -y
+        - composer install --optimize-autoloader
+        - drush cache:rebuild
+        - drush config:import -y
+        - drush updatedb -y
+        - ? drush cache
+
+    # Set up Visual Diffs to watch specific pages of the site and diff for changes.
+    # Use this Tugboat feature to check for visual regressions.
+    visualdiffs:
+      :default:
+        - /
+        - /example-page
 
   # What to call the service hosting MySQL. This name also acts as the
-  # hostname to access the service by from the php service.
+  # hostname to access the service from the php service.
   mysql:
     # Use the latest available 5.x version of MySQL
     image: tugboatqa/mysql:5

--- a/content/starter-configs/tutorials/drupal-9.md
+++ b/content/starter-configs/tutorials/drupal-9.md
@@ -45,7 +45,7 @@ $settings['hash_salt'] = hash('sha256', getenv('TUGBOAT_REPO_ID'));
 ## Configure Tugboat
 
 The Tugboat configuration is managed by a [YAML file](/setting-up-tugboat/create-a-tugboat-config-file/) at
-`.tugboat/config.yml` in the git repository. Here's a basic Drupal 8 configuration you can use as a starting point, with
+`.tugboat/config.yml` in the git repository. Here's a basic Drupal 9 configuration you can use as a starting point, with
 comments to explain what's going on:
 
 ```yaml


### PR DESCRIPTION
closes #208 

Here's a starting point. This is a duplicate of the Drupal 8 page, with references changed to Drupal 9. (I also reordered the Drupal tutorial pages to have D9 at the top, then D8, then D7.)

I went through the Tugboat config for Lullabot.com's D9 Tugboat build, which is working, and compared it to this. Most of the differences I saw appeared to be specific to Lullabot's hosting setup (Pantheon/Terminus). I'd love a second set of eyes @q0rban to take a look and make sure this should work for D9, or see if there's anything we need to add here for the D9 way of doing things.