### PR TITLE
Add documentation for online, start, clone, ready

### DIFF
--- a/content/reference/tugboat-configuration.md
+++ b/content/reference/tugboat-configuration.md
@@ -1,6 +1,7 @@
 ---
 title: "Tugboat Configuration"
 date: 2019-09-17T11:26:18-04:00
+lastmod: 2020-07-20T15:00:00-04:00
 weight: 4
 ---
 
@@ -134,6 +135,9 @@ See also: [Service Commands](/setting-up-services/how-to-set-up-services/leverag
 | update | Commands that import data or other assets into a service, such as a database or image files            |
 | build  | Commands that build or generate the site, such as compiling Sass or running database updates from code |
 | ready  | Commands that indicate that a service is "ready", such as checking for a listening TCP port            |
+| online | Commands to run once, after a Preview has built, is online, and is ready to accept incoming requests   |
+| start  | Commands that should be run every time a Preview starts                                                |
+| clone  | Commands that should be run on the cloned (new) Preview that has been created from an existing Preview |
 
 The `init`, `update`, and `build` stages are related as follows:
 
@@ -144,6 +148,10 @@ The `init`, `update`, and `build` stages are related as follows:
   the commands in `update` are run, followed by the commands in `build`.
 
 - When a Preview is created from a Base Preview, only the commands in `build` are run.
+
+The `online`, `start`, and `clone` commands all run after the build snapshot, so these commands are executed after the
+build is complete (although `clone`ed commands are committed as a second build snapshot). For more info on the build
+snapshot, see: [The Build Snapshot](/building-a-preview/preview-deep-dive/how-previews-work#the-build-snapshot).
 
 ---
 

--- a/content/setting-up-services/how-to-set-up-services/leverage-service-commands.md
+++ b/content/setting-up-services/how-to-set-up-services/leverage-service-commands.md
@@ -1,12 +1,20 @@
 +++
 title = "Leverage Service Commands"
 date = 2019-09-19T13:03:56-04:00
+lastmod = 2020-07-20T15:00:00-04:00
 weight = 3
 +++
 
 While technically optional, Service Commands are arguably the most powerful part of the
 [configuration file](/setting-up-tugboat/create-a-tugboat-config-file/). This is the set of commands that Tugboat runs
 in a Service container while creating a Preview.
+
+Tugboat's service commands fit into two categories:
+
+- [Service commands to run during Preview build](#service-commands-to-run-during-preview-build)
+- [Service commands to run after Preview build](#service-commands-to-run-after-preview-build)
+
+## Service commands to run during Preview build
 
 The service commands are separated into a set of stages: `init`, `update`, and `build`. Each stage represents an
 optional set of commands that Tugboat should run during that stage. For more info on the stages in the Preview build
@@ -24,6 +32,13 @@ stages roughly represent the following purposes:
 
 - **build** - Run commands that build or generate the actual site. This might include things like compiling Sass files,
   updating 3rd party libraries, or running database updates that the current code in the preview depends on.
+
+At any point during the build process, you can use the `ready` command to indicate that a service is "ready" before
+proceeding with the build, such as checking for a listening TCP port. However, if you use `ready` to check for something
+that doesn't happen until _after_ the command would execute, the Preview can get stuck building indefinitely. For
+example, in a Node.js app, you might be tempted to use `ready` to check that port 3,000 is responding, but when the app
+is building and the `ready` command would execute the first time, you wouldn't have anything started on port 3,000 yet,
+so the Preview will get stuck and the build process will never complete.
 
 {{% notice info %}} Each command is run in its own context, meaning things like `cd` do not "stick" between commands. If
 that behavior is required, an external script should be included in the git repository and called from the config file.
@@ -53,3 +68,55 @@ services:
 
 Notice that each stage is optional for a given service. There may not be any commands required for that service during
 some stage. When that is the case, the stage can be excluded completely.
+
+## Service commands to run after Preview build
+
+You can also configure service commands to run _after_ a Tugboat Preview has built. The three service commands that run
+after the build process are:
+
+- **start** - Run commands every time a Preview container starts. This happens any time the container starts; after a
+  Preview has [suspended](/building-a-preview/preview-deep-dive/how-previews-work#status-message) or been
+  [stopped](/building-a-preview/administer-previews/change-preview-states#start-stop); or if you
+  [Reset](/building-a-preview/administer-previews/change-preview-states#reset) the Preview. `start` might be useful for
+  [running a background process](../running-a-background-process/); to warm up caches, for example.
+- **online** - Run commands once, after a Preview build has completed. These commands only run after the Preview
+  snapshot, when a Preview has been through **Build**, **Rebuild** or **Refresh**. For more info on the build process
+  and build snapshots, see: [How Previews Work](/building-a-preview/preview-deep-dive/how-previews-work/).
+- **clone** - Run commands on the cloned (new) Preview that has been created from another Preview. Commands that you run
+  in `clone` get committed as part of the build snapshot, so things like Resetting an image do not erase `clone`
+  commands. For more info, see: [How Previews Work](/building-a-preview/preview-deep-dive/how-previews-work/).
+
+For an example of the `online` command, here's a sample code snippet from
+[our Diffy integration](/starter-configs/code-snippets/diffy-integration/):
+
+```yaml
+services:
+  apache:
+    image: tugboatqa/httpd:2.4
+    default: true
+    commands:
+      init:
+        # The Diffy CLI tool requires PHP. If the service image does not have PHP
+        # installed, do it here
+        #- apt-get update
+        #- apt-get install php-cli
+
+        # Download the Diffy CLI tool, and authenticate. The latest version can be
+        # found at https://github.com/DiffyWebsite/diffy-cli/releases
+        - curl -L https://github.com/DiffyWebsite/diffy-cli/releases/download/0.1.2/diffy.phar -o /usr/local/bin/diffy
+        - chmod +x /usr/local/bin/diffy
+        - diffy auth:login $DIFFY_API_KEY
+
+        # Clean up after apt-get, if it was used
+        #- apt-get clean
+        #- rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+      online:
+        # Compare this service with production
+        - diffy project:compare $DIFFY_PROJECT_ID prod custom --env2Url=$TUGBOAT_SERVICE_URL
+
+        # Compare this service with the base preview
+        - if [ "x$TUGBOAT_BASE_PREVIEW_URL" != "x" ]; then diffy project:compare $DIFFY_PROJECT_ID custom custom
+          --env1Url=$TUGBOAT_BASE_PREVIEW_URL --env2Url=$TUGBOAT_SERVICE_URL; fi
+```
+
+The `start` and `clone` commands would run in a similar command context.

--- a/content/setting-up-services/how-to-set-up-services/leverage-service-commands.md
+++ b/content/setting-up-services/how-to-set-up-services/leverage-service-commands.md
@@ -77,7 +77,7 @@ after the build process are:
   snapshot, when a Preview has been through **Build**, **Rebuild** or **Refresh**. For more info on the build process
   and build snapshots, see: [How Previews Work](/building-a-preview/preview-deep-dive/how-previews-work/).
 
-For an example of the `online` command, here's a sample code snippet from
+For an example of the `online` and `start` commands, here's a sample code snippet from
 [our Diffy integration](/starter-configs/code-snippets/diffy-integration/):
 
 ```yaml
@@ -87,22 +87,16 @@ services:
     default: true
     commands:
       init:
-        # The Diffy CLI tool requires PHP. If the service image does not have PHP
-        # installed, do it here
-        #- apt-get update
-        #- apt-get install php-cli
-
-        # Download the Diffy CLI tool, and authenticate. The latest version can be
-        # found at https://github.com/DiffyWebsite/diffy-cli/releases
+        # Download the Diffy CLI tool, and authenticate.
         - curl -L https://github.com/DiffyWebsite/diffy-cli/releases/download/0.1.2/diffy.phar -o /usr/local/bin/diffy
         - chmod +x /usr/local/bin/diffy
         - diffy auth:login $DIFFY_API_KEY
-
-        # Clean up after apt-get, if it was used
-        #- apt-get clean
-        #- rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+      start:
+        # Warm the cache
+        - sudo -u www-data /var/lib/tugboat/vendor/bin/drush --root /var/lib/tugboat/web warmer:enqueue -l localhost
+          --verbose --run-queue
       online:
-        # Compare this service with production
+        # Compare this service with production using Diffy
         - diffy project:compare $DIFFY_PROJECT_ID prod custom --env2Url=$TUGBOAT_SERVICE_URL
 
         # Compare this service with the base preview

--- a/content/setting-up-services/how-to-set-up-services/leverage-service-commands.md
+++ b/content/setting-up-services/how-to-set-up-services/leverage-service-commands.md
@@ -13,6 +13,7 @@ Tugboat's service commands fit into two categories:
 
 - [Service commands to run during Preview build](#service-commands-to-run-during-preview-build)
 - [Service commands to run after Preview build](#service-commands-to-run-after-preview-build)
+- [Additional service commands](#additional-service-commands)
 
 ## Service commands to run during Preview build
 
@@ -32,13 +33,6 @@ stages roughly represent the following purposes:
 
 - **build** - Run commands that build or generate the actual site. This might include things like compiling Sass files,
   updating 3rd party libraries, or running database updates that the current code in the preview depends on.
-
-At any point during the build process, you can use the `ready` command to indicate that a service is "ready" before
-proceeding with the build, such as checking for a listening TCP port. However, if you use `ready` to check for something
-that doesn't happen until _after_ the command would execute, the Preview can get stuck building indefinitely. For
-example, in a Node.js app, you might be tempted to use `ready` to check that port 3,000 is responding, but when the app
-is building and the `ready` command would execute the first time, you wouldn't have anything started on port 3,000 yet,
-so the Preview will get stuck and the build process will never complete.
 
 {{% notice info %}} Each command is run in its own context, meaning things like `cd` do not "stick" between commands. If
 that behavior is required, an external script should be included in the git repository and called from the config file.
@@ -71,7 +65,7 @@ some stage. When that is the case, the stage can be excluded completely.
 
 ## Service commands to run after Preview build
 
-You can also configure service commands to run _after_ a Tugboat Preview has built. The three service commands that run
+You can also configure service commands to run _after_ a Tugboat Preview has built. The two service commands that run
 after the build process are:
 
 - **start** - Run commands every time a Preview container starts. This happens any time the container starts; after a
@@ -82,9 +76,6 @@ after the build process are:
 - **online** - Run commands once, after a Preview build has completed. These commands only run after the Preview
   snapshot, when a Preview has been through **Build**, **Rebuild** or **Refresh**. For more info on the build process
   and build snapshots, see: [How Previews Work](/building-a-preview/preview-deep-dive/how-previews-work/).
-- **clone** - Run commands on the cloned (new) Preview that has been created from another Preview. Commands that you run
-  in `clone` get committed as part of the build snapshot, so things like Resetting an image do not erase `clone`
-  commands. For more info, see: [How Previews Work](/building-a-preview/preview-deep-dive/how-previews-work/).
 
 For an example of the `online` command, here's a sample code snippet from
 [our Diffy integration](/starter-configs/code-snippets/diffy-integration/):
@@ -119,4 +110,65 @@ services:
           --env1Url=$TUGBOAT_BASE_PREVIEW_URL --env2Url=$TUGBOAT_SERVICE_URL; fi
 ```
 
-The `start` and `clone` commands would run in a similar command context.
+The `start` command would run in a similar command context.
+
+## Additional service commands
+
+In addition to service commands that run during the build process, and service commands that execute after the build
+snapshot is complete, there are two more service commands you can use in your Tugboat builds: `clone` and `ready`.
+
+- [Clone](#clone-commands)
+- [Ready](#the-ready-command)
+
+### Clone commands
+
+When you use `clone` commands in your config.yml, these commands will only run on the cloned (new) Preview that has been
+created from an existing Preview using
+[Clone](/building-a-preview/administer-previews/build-previews/#duplicate-a-preview).
+
+Under the covers, Clone duplicates a Preview at the time of
+[the build snapshot](/building-a-preview/preview-deep-dive/how-previews-work/#the-build-snapshot). Commands you include
+in your `.tugboat/config.yml` as `clone` service commands then run on the duplicated (new) Preview, and then _that_
+version of the Preview is committed as a build snapshot, overwriting the original duplicated Preview. As a result,
+commands that you run in `clone` get committed as part of the build snapshot, so they become permanently part of the
+Preview. Things like [Reset](/building-a-preview/administer-previews/change-preview-states/#reset) do not erase `clone`
+commands, and those commands would carry over if you made a Preview cloned in this way a Base Preview.
+
+### The `ready` command
+
+An additional service command you might find useful in some cases is the `ready` command. When you use `ready` as a
+[service command](../leverage-service-commands/), you're telling Tugboat to check whether the condition is true, and if
+yes, then continue the Preview build. If the condition is not true, `ready` waits and then checks the condition again.
+
+Common use cases for the `ready` command include things like checking whether a port is listening, such as checking for
+a `mysql` connection when running `php` services.
+
+The caveat for the `ready` command is that the command you try to execute must be able to pass _before_ the app is
+installed, because Tugboat needs to spin up the service prior to the app being installed. So if a `ready` command
+depends on the app being installed, Tugboat would be stuck forever checking for a condition that will never pass, and
+the build process will eventually time out.
+
+When using `ready` to check for something that doesn't happen until _after_ the command would execute, the Preview will
+get stuck building indefinitely. For example, in a Node.js app, you might be tempted to use `ready` to check that port
+3,000 is responding, but when the app is building and the `ready` command would execute the first time, you wouldn't
+have anything started on port 3,000 yet, so the Preview will get stuck and the build process will never complete.
+
+There are a couple of ways around this; for example, you could add a delay to give extra time for a Node.js app to start
+up using something like: `ready: "! test -f ${TUGBOAT_ROOT}/.tugboat/config.yml || sleep 20"`.
+
+Or you could add something like this as an external script:
+
+```
+.tugboat/node-ready.sh:
+#!/bin/sh set -eu curl \ --silent \ --retry 50 \ --retry-delay 1 \ --retry-connrefused \ --max-time 4 \ --retry-max-time 240 \ localhost:3000 > /dev/null || true
+```
+
+Which will try to make a request to `localhost` on port 3000 until there's a response. Then, you could add this line to
+your [Tugboat `config.yml`](/setting-up-tugboat/create-a-tugboat-config-file/):
+
+```yaml
+ready: - 'test ! -x $TUGBOAT_ROOT/.tugboat/node-ready.sh || $TUGBOAT_ROOT/.tugboat/node-ready.sh'
+```
+
+This will make sure the `ready` command passes if the `node-ready.sh` script isn't available yet, and if it _is_
+available, it will execute it to see if the Node.js app is running.

--- a/content/setting-up-services/how-to-set-up-services/running-a-background-process.md
+++ b/content/setting-up-services/how-to-set-up-services/running-a-background-process.md
@@ -1,6 +1,7 @@
 +++
 title = "Running a Background Process"
 date = 2019-09-19T13:05:11-04:00
+lastmod = 2020-07-20T15:00:00-04:00
 weight = 8
 +++
 
@@ -10,6 +11,13 @@ has not finished building, and it will be stuck in the "building" state until it
 
 {{% notice info %}} The reason Tugboat needs to wait for all of the `build` commands to finish is that we stop the
 Services after a Preview build is finished in order to take a snapshot. {{% /notice %}}
+
+You can use two techniques to run a background process:
+
+- [Use a Tugboat image that contains `runit` to start a build script independent of the Preview build process.](#use-runit-in-an-official-tugboat-image)
+- [Use the `ready` command to indicate a service is "ready."](#use-the-ready-command)
+
+## Use runit in an official Tugboat image
 
 Our [prebuilt images](../../service-images/using-tugboat-images/) use [runit](http://smarden.org/runit/) to start and
 manage background processes.
@@ -40,3 +48,38 @@ services:
           - echo "npm start --prefix ${TUGBOAT_ROOT}" >> /etc/service/node/run
           - chmod +x /etc/service/node/run
 ```
+
+## Use the ready command
+
+If you're using your own custom image that does not include `runit`, or you have other use cases for running a
+background process, you can use the `ready` command. When you use `ready` as a
+[service command](../leverage-service-commands/), you're telling Tugboat to check whether the condition is true, and if
+yes, then continue the Preview build. If the condition is not true, `ready` waits and then checks the condition again.
+
+Common use cases for the `ready` command include things like checking whether a port is listening, such as checking for
+a `mysql` connection when running `php` services.
+
+The caveat for the `ready` command is that the command you try to execute must be able to pass _before_ the app is
+installed, because Tugboat needs to spin up the service prior to the app being installed. So if a `ready` command
+depends on the app being installed, Tugboat would be stuck forever checking for a condition that will never pass, and
+the build process will eventually time out.
+
+There are a couple of ways around this; for example, you could add a delay to give extra time for a Node.js app to start
+up using something like: `ready: "! test -f ${TUGBOAT_ROOT}/.tugboat/config.yml || sleep 20"`.
+
+Or you could add something like this as an external script:
+
+```
+.tugboat/node-ready.sh:
+#!/bin/sh set -eu curl \ --silent \ --retry 50 \ --retry-delay 1 \ --retry-connrefused \ --max-time 4 \ --retry-max-time 240 \ localhost:3000 > /dev/null || true
+```
+
+Which will try to make a request to `localhost` on port 3000 until there's a response. Then, you could add this line to
+your [Tugboat `config.yml`](/setting-up-tugboat/create-a-tugboat-config-file/):
+
+```yaml
+ready: - 'test ! -x $TUGBOAT_ROOT/.tugboat/node-ready.sh || $TUGBOAT_ROOT/.tugboat/node-ready.sh'
+```
+
+This will make sure the `ready` command passes if the `node-ready.sh` script isn't available yet, and if it _is_
+available, it will execute it to see if the Node.js app is running.

--- a/content/setting-up-services/how-to-set-up-services/running-a-background-process.md
+++ b/content/setting-up-services/how-to-set-up-services/running-a-background-process.md
@@ -15,7 +15,7 @@ Services after a Preview build is finished in order to take a snapshot. {{% /not
 You can use two techniques to run a background process:
 
 - [Use a Tugboat image that contains `runit` to start a build script independent of the Preview build process.](#use-runit-in-an-official-tugboat-image)
-- [Use the `ready` command to indicate a service is "ready."](#use-the-ready-command)
+- [Use the `start` command to start a background process](#use-the-start-command)
 
 ## Use runit in an official Tugboat image
 
@@ -49,37 +49,22 @@ services:
           - chmod +x /etc/service/node/run
 ```
 
-## Use the ready command
+## Use the start command
 
-If you're using your own custom image that does not include `runit`, or you have other use cases for running a
-background process, you can use the `ready` command. When you use `ready` as a
-[service command](../leverage-service-commands/), you're telling Tugboat to check whether the condition is true, and if
-yes, then continue the Preview build. If the condition is not true, `ready` waits and then checks the condition again.
+If you're not using a Tugboat image that contains `runit` to start a long-running background process, another option is
+to use the `start` service command. Commands that you include in `start` in your `.tugboat/config.yml` will run every
+time the container starts. You might use this to warm a page cache, for example.
 
-Common use cases for the `ready` command include things like checking whether a port is listening, such as checking for
-a `mysql` connection when running `php` services.
-
-The caveat for the `ready` command is that the command you try to execute must be able to pass _before_ the app is
-installed, because Tugboat needs to spin up the service prior to the app being installed. So if a `ready` command
-depends on the app being installed, Tugboat would be stuck forever checking for a condition that will never pass, and
-the build process will eventually time out.
-
-There are a couple of ways around this; for example, you could add a delay to give extra time for a Node.js app to start
-up using something like: `ready: "! test -f ${TUGBOAT_ROOT}/.tugboat/config.yml || sleep 20"`.
-
-Or you could add something like this as an external script:
-
-```
-.tugboat/node-ready.sh:
-#!/bin/sh set -eu curl \ --silent \ --retry 50 \ --retry-delay 1 \ --retry-connrefused \ --max-time 4 \ --retry-max-time 240 \ localhost:3000 > /dev/null || true
-```
-
-Which will try to make a request to `localhost` on port 3000 until there's a response. Then, you could add this line to
-your [Tugboat `config.yml`](/setting-up-tugboat/create-a-tugboat-config-file/):
+Start works like other
+[service commands](/setting-up-services/how-to-set-up-services/leverage-service-commands/#service-commands-to-run-after-preview-build),
+so your config might look something like this:
 
 ```yaml
-ready: - 'test ! -x $TUGBOAT_ROOT/.tugboat/node-ready.sh || $TUGBOAT_ROOT/.tugboat/node-ready.sh'
+services:
+  php:
+    commands:
+      start:
+        # Warm the cache
+        - sudo -u www-data /var/lib/tugboat/vendor/bin/drush --root /var/lib/tugboat/web warmer:enqueue -l localhost
+          --verbose --run-queue
 ```
-
-This will make sure the `ready` command passes if the `node-ready.sh` script isn't available yet, and if it _is_
-available, it will execute it to see if the Node.js app is running.

--- a/content/setting-up-services/how-to-set-up-services/running-a-background-process.md
+++ b/content/setting-up-services/how-to-set-up-services/running-a-background-process.md
@@ -33,7 +33,7 @@ For example, the following `run` script would start Apache:
 exec httpd-foreground
 ```
 
-Below is an example of how you might configure a NodeJS process to start. Keep in mind that `runit` will try to start
+Below is an example of how you might configure a Node.JS process to start. Keep in mind that `runit` will try to start
 the process as soon as the `run` script is present in the Service directory. So, set it up after any other build steps
 that it might depend on.
 
@@ -57,14 +57,13 @@ time the container starts. You might use this to warm a page cache, for example.
 
 Start works like other
 [service commands](/setting-up-services/how-to-set-up-services/leverage-service-commands/#service-commands-to-run-after-preview-build),
-so your config might look something like this:
+so if you wanted to do something like starting a Node.JS process above but _without_ using `runit`, your config might
+look something like this:
 
 ```yaml
 services:
   php:
     commands:
       start:
-        # Warm the cache
-        - sudo -u www-data /var/lib/tugboat/vendor/bin/drush --root /var/lib/tugboat/web warmer:enqueue -l localhost
-          --verbose --run-queue
+        - npm start --prefix ${TUGBOAT_ROOT} &
 ```

--- a/content/troubleshooting/preview-built-problem.md
+++ b/content/troubleshooting/preview-built-problem.md
@@ -1,6 +1,7 @@
 ---
 title: "Preview has built incorrectly"
 date: 2019-09-19T12:38:53-04:00
+lastmod: 2020-07-20T15:00:00-04:00
 weight: 2
 ---
 
@@ -162,6 +163,13 @@ To troubleshoot where this might have gone wrong:
 
 If you can't figure out why something isn't as you expect in your Preview, let us know! Visit us at
 [Help and Support](/support/); we're happy to help.
+
+{{% notice tip %}} If you're using the `online`, `start`, or `clone` service commands to run additional commands after a
+Preview has built, and you're not getting the expected result, you may be running into a caveat about the conditions
+under which the commands run. Take a look at
+[service commands to run after Preview build](/setting-up-services/how-to-set-up-services/leverage-service-commands/#service-commands-to-run-after-preview-build),
+and feel free to reach out at [Help and Support](/support/) if you can't figure out which command is problematic.
+{{% /notice %}}
 
 ## Troubleshooting Visual Diffs
 

--- a/content/troubleshooting/preview-wont-build.md
+++ b/content/troubleshooting/preview-wont-build.md
@@ -1,6 +1,7 @@
 ---
 title: "Preview Won't Build"
 date: 2019-09-19T12:38:29-04:00
+lastmod: 2020-07-20T15:00:00-04:00
 weight: 1
 ---
 
@@ -41,6 +42,11 @@ When you're ready to troubleshoot, start by taking a
 into where the Preview is in the build process. If you see that the Preview build isn't progressing, checking out where
 it got stuck is a great place to start [debugging the Config file](../debug-config-file/) and figuring out what's
 causing the Preview build to hang.
+
+{{% notice tip %}} If your build is getting "stuck" and you're trying to run a background process, there may be an issue
+with the command you're trying to execute not being possible until the app has built. Take a look at
+[running a background process](/setting-up-services/how-to-set-up-services/running-a-background-process/), and feel free
+to reach out at [Help and Support](/support/) if you can't figure out where it's hanging. {{% /notice %}}
 
 If your builds are taking longer than expected, but there isn't an issue in your config file causing problems, take a
 look at [Optimize your Preview builds](/building-a-preview/preview-deep-dive/optimize-preview-builds/) for a few things


### PR DESCRIPTION
I've added documentation for the new service commands, `online`, `start`, and `clone`, and after chatting about these with Ben, have concluded it's time to build out the `ready` command documentation more so it has parity with the rest of the service commands. So I've added documentation for that here, too.

I've added content in several place in the docs site (check out changed files) but have not touched the "How Previews Work -> The Build Process Explained" documentation. I'm not sure that the documentation there needs to change, actually. Although I'm wondering if I should build out more content about the Build Snapshot, as we're now referencing that for some of the new service command documentation. I'm also uncertain about whether we need to update the build phase diagram, or create a new one for the post-build commands. Thoughts?

This documentation closes #139 .