### PR TITLE
Add API documentation link to front page

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -17,6 +17,10 @@ Bitbucket git repositories.
 This website aims to provide the information required to use Tugboat. It includes tutorials, examples, and references
 for all experience levels.
 
+## API Documentation
+
+If you're looking for our API documentation, check out [Tugboat's API Documentation Portal](https://api.tugboat.qa).
+
 ## Contributing
 
 This document is open-source, and is available on [GitHub](https://github.com/TugboatQA/docs). If you have any


### PR DESCRIPTION
I've been thinking about the API documentation, and I'd like to get the link here on the docs front page as a starting point.

Bigger-picture, it would be good to create some cross-links to the documentation portal from the API docs, I think. The endpoints are all documented, but the API docs assume that people who are consuming them are familiar with how Tugboat works, and assume developers are familiar with what the docs mean when we say things like "projects" "repositories" "previews" "services" and "visual diffs." 

I think an incremental improvement we could offer is to provide links from the API docs to the main docs site at the beginning of each API doc section for "concept" explanation, so we're not trying to maintain that info in two places. Currently, the "concepts" are documented inconsistently. For example, the `Preview -> Reset` and `Preview -> Rekey` POST commands have concept explanations, but the rest of the Preview POST commands lack them. 

Short-term, I think we should add the Google Analytics Rollup ID to the API documentation so we have some idea how many folks are consuming it, and that info can help us prioritize when/how much work to put into improving the API docs.