### PR TITLE
Remove first-cpu-idle from Lighthouse docs; it's deprecated

### DIFF
--- a/content/lighthouse/configure-lighthouse.md
+++ b/content/lighthouse/configure-lighthouse.md
@@ -86,15 +86,13 @@ services:
       # Trigger a Lighthouse audit for /blog, but override the default config with a custom config object
       - url: /blog
         lighthouse:
-          config: {
-            extends: 'lighthouse:default',
-            settings: {
-              onlyAudits: [
-                'first-meaningful-paint',
-                'speed-index',
-                'interactive',
-              ],
-            }
+          config:
+            extends: lighthouse:default
+            settings:
+              onlyAudits:
+                - first-meaningful-paint
+                - speed-index
+                - interactive
 
       # Turn off Lighthouse audits for /about, but leave the URL in the list for other Service URL activities, such as generating visual diffs
       - url: /about

--- a/content/lighthouse/configure-lighthouse.md
+++ b/content/lighthouse/configure-lighthouse.md
@@ -59,7 +59,6 @@ services:
           onlyAudits:
             - first-meaningful-paint
             - speed-index
-            - first-cpu-idle
             - interactive
     urls:
       # Conduct Lighthouse audits of the these URLs using the custom config
@@ -93,7 +92,6 @@ services:
               onlyAudits: [
                 'first-meaningful-paint',
                 'speed-index',
-                'first-cpu-idle',
                 'interactive',
               ],
             }


### PR DESCRIPTION
Resolves #315