### PR TITLE
Document Tugboat merging behavior

### DIFF
--- a/content/building-a-preview/administer-previews/build-previews.md
+++ b/content/building-a-preview/administer-previews/build-previews.md
@@ -81,6 +81,21 @@ out multiple Previews. Check out our section on
 [Optimizing Preview builds](../../preview-deep-dive/optimize-preview-builds/) for tips on
 [reducing Preview size](../../preview-deep-dive/optimize-preview-builds/#optimizing-preview-size). {{% /notice %}}
 
+### Pull Request Merging Behavior
+
+When building a preview from a pull request, Tugboat will first merge the branch locally before building the preview. This
+allows you to test your project in the state it will be in after the pull request is merged. In particular, this is useful
+for identifying bugs and regressions that only happen when code in your main or other branch exposes bugs only in combination
+with the changes in the pull request.
+
+Sometimes, it can be useful to test a pull request without first merging code, such as when the only conflicts are in
+generated files like package manager lock files. To trigger a build without a merge:
+
+1. Delete any existing pull request previews.
+2. In Tugboat, build a preview from the _branch_ or _tag_ instead of from a _pull request_. Since there's no implicit merge
+   destination, Tugboat will build without a merge.
+3. In the case of a branch, Tugboat will still post environment URLs to the pull request.
+
 ## Auto-generate a Preview
 
 In addition to manually building a Preview when you've got an update, you can configure Tugboat to automatically build a

--- a/content/building-a-preview/administer-previews/build-previews.md
+++ b/content/building-a-preview/administer-previews/build-previews.md
@@ -83,17 +83,17 @@ out multiple Previews. Check out our section on
 
 ### Pull Request Merging Behavior
 
-When building a preview from a pull request, Tugboat will first merge the branch locally before building the preview. This
-allows you to test your project in the state it will be in after the pull request is merged. In particular, this is useful
-for identifying bugs and regressions that only happen when code in your main or other branch exposes bugs only in combination
-with the changes in the pull request.
+When building a preview from a pull request, Tugboat will first merge the branch locally before building the preview.
+This allows you to test your project in the state it will be in after the pull request is merged. In particular, this is
+useful for identifying bugs and regressions that only happen when code in your main or other branch exposes bugs only in
+combination with the changes in the pull request.
 
 Sometimes, it can be useful to test a pull request without first merging code, such as when the only conflicts are in
 generated files like package manager lock files. To trigger a build without a merge:
 
 1. Delete any existing pull request previews.
-2. In Tugboat, build a preview from the _branch_ or _tag_ instead of from a _pull request_. Since there's no implicit merge
-   destination, Tugboat will build without a merge.
+2. In Tugboat, build a preview from the _branch_ or _tag_ instead of from a _pull request_. Since there's no implicit
+   merge destination, Tugboat will build without a merge.
 
 ## Auto-generate a Preview
 

--- a/content/building-a-preview/administer-previews/build-previews.md
+++ b/content/building-a-preview/administer-previews/build-previews.md
@@ -94,7 +94,6 @@ generated files like package manager lock files. To trigger a build without a me
 1. Delete any existing pull request previews.
 2. In Tugboat, build a preview from the _branch_ or _tag_ instead of from a _pull request_. Since there's no implicit merge
    destination, Tugboat will build without a merge.
-3. In the case of a branch, Tugboat will still post environment URLs to the pull request.
 
 ## Auto-generate a Preview
 

--- a/content/building-a-preview/automate-previews/auto-generate.md
+++ b/content/building-a-preview/automate-previews/auto-generate.md
@@ -9,7 +9,8 @@ We love automatically generating Previews from new pull requests - we think it's
 is opened in your linked git repository.
 
 If you're [using a Base Preview](/building-a-preview/work-with-base-previews/), the automated Preview build starts from
-that Base Preview.
+that Base Preview. When building previews from pull requests, Tugboat will locally merge the pull request into it's
+destination branch, and build from the merged result.
 
 {{% notice warning %}} When you enable this functionality, Tugboat does not automatically build pull requests from
 forked repositories. That requires you to set an additional option: **Build Previews for Forked Pull Requests**. Any
@@ -58,3 +59,9 @@ Press the {{% ui-text %}}Save Configuration{{% /ui-text %}} button to save your 
 ![Press the Save Configuration button](/_images/repository-settings-press-save-configuration.png)
 
 {{% /expand%}}
+
+## To Build a Preview with Conflicts
+
+Sometimes you may want to build a preview in a pull request, even if it has conflicts with the destination branch.
+To build the preview without first merging, delete the automatically created preview and then
+[Build a Preview](/building-a-preview/administer-previews/build-previews/) from the _branch_ instead of the  _pull request_.

--- a/content/building-a-preview/automate-previews/auto-generate.md
+++ b/content/building-a-preview/automate-previews/auto-generate.md
@@ -62,6 +62,7 @@ Press the {{% ui-text %}}Save Configuration{{% /ui-text %}} button to save your 
 
 ## To Build a Preview with Conflicts
 
-Sometimes you may want to build a preview in a pull request, even if it has conflicts with the destination branch.
-To build the preview without first merging, delete the automatically created preview and then
-[Build a Preview](/building-a-preview/administer-previews/build-previews/) from the _branch_ instead of the  _pull request_.
+Sometimes you may want to build a preview in a pull request, even if it has conflicts with the destination branch. To
+build the preview without first merging, delete the automatically created preview and then
+[Build a Preview](/building-a-preview/administer-previews/build-previews/) from the _branch_ instead of the _pull
+request_.

--- a/content/building-a-preview/automate-previews/auto-generate.md
+++ b/content/building-a-preview/automate-previews/auto-generate.md
@@ -9,7 +9,7 @@ We love automatically generating Previews from new pull requests - we think it's
 is opened in your linked git repository.
 
 If you're [using a Base Preview](/building-a-preview/work-with-base-previews/), the automated Preview build starts from
-that Base Preview. When building previews from pull requests, Tugboat will locally merge the pull request into it's
+that Base Preview. When building previews from pull requests, Tugboat will locally merge the pull request into its
 destination branch, and build from the merged result.
 
 {{% notice warning %}} When you enable this functionality, Tugboat does not automatically build pull requests from


### PR DESCRIPTION
This came out of a mini show-and-tell I did with a customer on how to build when there are Composer conflicts, especially in long-lived feature branches.