### PR TITLE
Changed link to GitHub tag "tugboat-starter-kit".

### DIFF
--- a/content/starter-configs/_index.md
+++ b/content/starter-configs/_index.md
@@ -11,7 +11,7 @@ pre = "<b></b>"
 # Starter Configs
 
 In addition to these code snippets and tutorials, we also maintain repositories with
-[starter configuration files](https://github.com/search?q=topic%3Astarter-kit+org%3ATugboatQA&type=Repositories) for
+[starter configuration files](https://github.com/search?q=topic%3Atugboat-starter-kit&type=Repositories) for
 other frameworks and Content Management Systems in our [GitHub account](https://github.com/TugboatQA).
 
 See our blog post:


### PR DESCRIPTION
Problem
- Contributed starter kits such as https://github.com/makers99/TugboatQA-WordPress-WooCommerce-Starter-Kit are not listed when following the link in the documentation.

Goal
- Encourage knowledge sharing with community contributed configurations.

Proposed solution
1. Change the link from the GitHub tag "starter-kit" in the TugboatQA organization to use the tag "tugboat-starter-kit" without restriction on organizations.
