### PR TITLE
#341 fix: use absolute path to solr binary

### DIFF
--- a/content/reference/tugboat-images.md
+++ b/content/reference/tugboat-images.md
@@ -167,7 +167,7 @@ services:
     checkout: true
     commands:
       init:
-        - su -s /bin/sh -c "solr create_core -c [CORE] -force" solr
+        - su -s /bin/sh -c "/opt/solr/bin/solr create_core -c [CORE] -force" solr
 
       build:
         - cd "${SOLR_HOME}/[CORE]" && rm -rf conf


### PR DESCRIPTION
Resolves #341 