### PR TITLE
Fix syntax

### DIFF
--- a/content/starter-configs/tutorials/drupal-8.md
+++ b/content/starter-configs/tutorials/drupal-8.md
@@ -82,7 +82,7 @@ services:
         - ln -snf "${TUGBOAT_ROOT}/web" "${DOCROOT}"
 
         # A common practice in many Drupal projects is to store the config and
-        # private files outside of the Drupal root. If that's the case for your
+        # private files outside the Drupal root. If that's the case for your
         # project, you can either specify the absolute paths to those
         # directories in your settings.local.php, or you can symlink them in
         # here. Here is an example of the latter option:


### PR DESCRIPTION
Fix syntax. I think "Outside of the Drupal root" should be "Outside of Drupal root. Could be?