### PR TITLE
docs: adjust node install snippet for gatsby

### DIFF
--- a/content/starter-configs/examples/gatsby.md
+++ b/content/starter-configs/examples/gatsby.md
@@ -24,8 +24,15 @@ services:
       # Initialize the server.
       init:
         # Install node.js version 18.
-        - curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
-        - apt-get install -y nodejs
+        - apt-get update
+        - apt-get install -yq ca-certificates curl gnupg
+        - mkdir -p /etc/apt/keyrings
+        - curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o
+          /etc/apt/keyrings/nodesource.gpg
+        - echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" |
+          tee /etc/apt/sources.list.d/nodesource.list
+        - apt-get update
+        - apt-get install -yq nodejs
 
         # Set the webroot for to the Gatsby public folder.
         # Change this if you specify a different root for your public site.


### PR DESCRIPTION
Makes an adjustment to the Gatsby `.tugboat/config.yml` config snippet. This is the same adjustment already made to Starter Configs > Code Snipptes > Install Node.js, which was done in https://github.com/TugboatQA/docs/pull/369.