### PR TITLE
Fix shortcode "children" must be closed or self-closed

### DIFF
--- a/content/administer-tugboat-crew/_index.md
+++ b/content/administer-tugboat-crew/_index.md
@@ -12,4 +12,4 @@ pre = "<b></b>"
 
 Add users, remove users, change permissions.
 
-{{% children  %}}
+{{% children  /%}}

--- a/content/building-a-preview/_index.md
+++ b/content/building-a-preview/_index.md
@@ -12,4 +12,4 @@ pre = "<b>3. </b>"
 
 How to build and update a Preview, administer Previews, and use Base Previews.
 
-{{% children depth="2" %}}
+{{% children depth="2" /%}}

--- a/content/building-a-preview/administer-previews/_index.md
+++ b/content/building-a-preview/administer-previews/_index.md
@@ -12,4 +12,4 @@ pre = "<b></b>"
 
 Build, update, and delete Previews. Change Preview states; Reset, Start/Stop, Lock/Unlock.
 
-{{% children %}}
+{{% children /%}}

--- a/content/building-a-preview/automate-previews/_index.md
+++ b/content/building-a-preview/automate-previews/_index.md
@@ -12,4 +12,4 @@ pre = "<b></b>"
 
 Automatically build, update, and delete Previews.
 
-{{% children %}}
+{{% children /%}}

--- a/content/building-a-preview/preview-deep-dive/_index.md
+++ b/content/building-a-preview/preview-deep-dive/_index.md
@@ -13,4 +13,4 @@ pre = "<b> </b>"
 Learn more about how Previews work, how you can optimize your Preview builds, and what you'll see when you click into a
 Preview in the Tugboat dashboard.
 
-{{% children %}}
+{{% children /%}}

--- a/content/building-a-preview/share-a-preview/_index.md
+++ b/content/building-a-preview/share-a-preview/_index.md
@@ -12,4 +12,4 @@ pre = "<b></b>"
 
 How to manually share a Preview, or configure automated posting of Preview URLs.
 
-{{% children %}}
+{{% children /%}}

--- a/content/building-a-preview/work-with-base-previews/_index.md
+++ b/content/building-a-preview/work-with-base-previews/_index.md
@@ -13,7 +13,7 @@ pre = "<b></b>"
 To speed up your Preview builds, and reduce subsequent Preview builds to smaller files, set a Base Preview as a starting
 point for child Previews.
 
-{{% children  %}}
+{{% children  /%}}
 
 Want to learn more about Base Previews under the cover? Check out:
 [How Base Previews work](../preview-deep-dive/how-previews-work/#how-base-previews-work).

--- a/content/faq/_index.md
+++ b/content/faq/_index.md
@@ -12,4 +12,4 @@ pre = "<b></b>"
 
 You've got questions? We've got answers!
 
-{{% children  %}}
+{{% children  /%}}

--- a/content/lighthouse/_index.md
+++ b/content/lighthouse/_index.md
@@ -12,4 +12,4 @@ pre = "<b></b>"
 
 Audit your Tugboat Previews for accessibility, SEO, and more using our Google Lighthouse integration.
 
-{{% children  %}}
+{{% children  /%}}

--- a/content/reference/_index.md
+++ b/content/reference/_index.md
@@ -12,4 +12,4 @@ pre = "<b></b>"
 
 Sometimes you just need to know more about a parameter or environment variable.
 
-{{% children  %}}
+{{% children  /%}}

--- a/content/setting-up-services/_index.md
+++ b/content/setting-up-services/_index.md
@@ -12,7 +12,7 @@ pre = "<b>2. </b>"
 
 How to set up Services, and more about images.
 
-{{% children depth="3" %}}
+{{% children depth="3" /%}}
 
 A Tugboat Service plays the role of what a server might provide in a production environment. A service can be a web
 server, a database server, a cache store, etc. Services form the core of your

--- a/content/setting-up-services/how-to-set-up-services/_index.md
+++ b/content/setting-up-services/how-to-set-up-services/_index.md
@@ -12,4 +12,4 @@ pre = "<b></b>"
 
 Taking you step-by-step through the process to set up Services in your config.yml file.
 
-{{% children  %}}
+{{% children  /%}}

--- a/content/setting-up-services/service-images/_index.md
+++ b/content/setting-up-services/service-images/_index.md
@@ -12,4 +12,4 @@ pre = "<b></b>"
 
 Details about Service images under the hood, including how to use your own Docker image and Tugboat-maintained images.
 
-{{% children  %}}
+{{% children  /%}}

--- a/content/setting-up-tugboat/_index.md
+++ b/content/setting-up-tugboat/_index.md
@@ -12,7 +12,7 @@ pre: "<b>1. </b>"
 
 Connecting Tugboat to your git provider, creating projects, adding repositories.
 
-{{% children  %}}
+{{% children  /%}}
 
 {{% notice tip %}} If you want to learn more about setting up Tugboat and get a feel for the overall workflow, watch our
 [Getting Started with Tugboat video](https://www.youtube.com/watch?v=HYTsrm5ORmU) on YouTube. {{% /notice %}}

--- a/content/starter-configs/_index.md
+++ b/content/starter-configs/_index.md
@@ -17,4 +17,4 @@ frameworks and Content Management Systems in our [GitHub account](https://github
 See our blog post:
 [10 Tips for Writing Your Tugboat YAML Config](https://www.tugboatqa.com/2021/02/02/Ten-Tips-For-Writing-Your-Tugboat-YAML-Config.html).
 
-{{% children depth="4" %}}
+{{% children depth="4" /%}}

--- a/content/starter-configs/code-snippets/_index.md
+++ b/content/starter-configs/code-snippets/_index.md
@@ -13,4 +13,4 @@ pre = "<b></b>"
 
 Example config.yml code stubs to use when adding functionality to your projects.
 
-{{% children  %}}
+{{% children  /%}}

--- a/content/starter-configs/examples/_index.md
+++ b/content/starter-configs/examples/_index.md
@@ -12,4 +12,4 @@ pre = ""
 
 Example config.yml files to get you started with common frameworks or configurations.
 
-{{% children  %}}
+{{% children  /%}}

--- a/content/starter-configs/tutorials/_index.md
+++ b/content/starter-configs/tutorials/_index.md
@@ -13,4 +13,4 @@ pre = ""
 
 Information about configuring frameworks to work with Tugboat, and example config.yml files to get you started.
 
-{{% children  %}}
+{{% children  /%}}

--- a/content/troubleshooting/_index.md
+++ b/content/troubleshooting/_index.md
@@ -12,4 +12,4 @@ pre = "<b></b>"
 
 How to figure out what went wrong, and fixes for common issues.
 
-{{% children %}}
+{{% children /%}}

--- a/content/tugboat-billing/_index.md
+++ b/content/tugboat-billing/_index.md
@@ -12,4 +12,4 @@ pre = "<b></b>"
 
 Tugboat pricing, how to change your Tugboat plan and billing information, and how to cancel Tugboat billing.
 
-{{% children %}}
+{{% children /%}}

--- a/content/tugboat-cli/_index.md
+++ b/content/tugboat-cli/_index.md
@@ -12,7 +12,7 @@ pre = "<b></b>"
 
 Installing and using Tugboat's CLI.
 
-{{% children %}}
+{{% children /%}}
 
 The Tugboat [Command Line Tool](https://dashboard.tugboatqa.com/downloads) provides access to your Tugboat account from
 your local command line. It allows you to perform all of the operations available through the web interface, as well as

--- a/content/visual-diffs/_index.md
+++ b/content/visual-diffs/_index.md
@@ -12,4 +12,4 @@ pre = "<b></b>"
 
 Use Tugboat's visual regression tools to visually diff changes to your sites.
 
-{{% children  %}}
+{{% children  /%}}


### PR DESCRIPTION
Running `yarn build` gave me an error: `shortcode "children" must be closed or self-closed`

See https://github.com/gohugoio/hugo/issues/10838

Apparently hugo 0.111 is more restrictive, and hugo 0.111 is the default in e.g. debian 12 repos (I'm using ddev). This should work in any previous version of hugo though.