### PR TITLE
Update drupal-10.md

### DIFF
--- a/content/starter-configs/tutorials/drupal-10.md
+++ b/content/starter-configs/tutorials/drupal-10.md
@@ -60,7 +60,7 @@ $settings['hash_salt'] = hash('sha256', getenv('TUGBOAT_REPO_ID'));
 ## Configure Tugboat
 
 The Tugboat configuration is managed by a [YAML file](/setting-up-tugboat/create-a-tugboat-config-file/) at
-`.tugboat/config.yml` in the git repository. Here's a basic Drupal 9 configuration you can use as a starting point, with
+`.tugboat/config.yml` in the git repository. Here's a basic Drupal 10 configuration you can use as a starting point, with
 comments to explain what's going on:
 
 ```yaml


### PR DESCRIPTION
fix a typo where it says a Drupal 9 config when we're reading a Drupal 10 example