### PR TITLE
Add Drupal recommended setting to set skip_permissions_hardening flag to TRUE

### DIFF
--- a/content/starter-configs/tutorials/drupal-10.md
+++ b/content/starter-configs/tutorials/drupal-10.md
@@ -55,6 +55,9 @@ $settings['hash_salt'] = hash('sha256', getenv('TUGBOAT_REPO_ID'));
 // web root, it's recommended to uncomment and adapt the following. Note: the
 // TUGBOAT_ROOT environment variable is equivalent to the git repo root.
 # $settings['file_private_path'] = getenv('TUGBOAT_ROOT') . '/files-private';
+
+// Prevent Drupal from making the sites/default directory unwritable.
+$settings['skip_permissions_hardening'] = TRUE;
 ```
 
 ## Configure Tugboat


### PR DESCRIPTION
Because Drupal after installing or updating, will attempt to make the web/sites/default directory unwritable, this causes errors if you have a Composer package that wants to update a file inside that directory (not the web/sites/default/files directory), such as [pantheon-systems/drupal-integration](https://github.com/pantheon-systems/drupal-integrations/blob/11.x/composer.json#L17) that manages the `web/sites/default/settings.pantheon.php` file, and [drupal/core](https://github.com/drupal/core/blob/11.x/composer.json#L149) wants to make sure the `sites/default/default.services.yml` and `sites/default/default.settings.php` files are always updated.