### PR TITLE
fix: ensure descenders are not cropped in headings

### DIFF
--- a/assets/css/theme-tugboat.css
+++ b/assets/css/theme-tugboat.css
@@ -166,6 +166,7 @@ textarea:focus, input[type="email"]:focus, input[type="number"]:focus, input[typ
 h1, h2, h3, h4, h5 {
     font-weight: bold;
     line-height: 1.2;
+    overflow: visible;
 }
 
 h1, #chapter * {


### PR DESCRIPTION
On prod in Firefox

<img width="511" height="100" alt="Setting Up Services :: Tugboat Documentation 2025-08-20 10-13-29" src="https://github.com/user-attachments/assets/e99da093-92a1-4ab9-88a1-0dfd6c1d15b0" />
