### PR TITLE
[setting-up-tugboat/_index.md] Remove Tip with link to old YouTube video

### DIFF
--- a/content/setting-up-tugboat/_index.md
+++ b/content/setting-up-tugboat/_index.md
@@ -9,6 +9,3 @@ pre: "<b>1. </b>"
 Connecting Tugboat to your git provider, creating projects, adding repositories.
 
 {{%children%}}
-
-{{% notice tip %}} If you want to learn more about setting up Tugboat and get a feel for the overall workflow, watch our
-[Getting Started with Tugboat video](https://www.youtube.com/watch?v=HYTsrm5ORmU) on YouTube. {{% /notice %}}


### PR DESCRIPTION
On the [Setting Up Tugboat](https://docs.tugboatqa.com/setting-up-tugboat/index.html) docs page, there's a Tip callout with a link to an ancient Tugboat video. This PR removes the Tip.