### PR TITLE
Enables line numbers in code blocks

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -17,6 +17,9 @@ home = [ "HTML", "RSS", "JSON"]
   [markup.goldmark]
     [markup.goldmark.renderer]
       unsafe = true
+  [markup.highlight]
+    lineNos = true
+    lineNumbersInTable = false
 
 [params]
   # Google Analytics ID, uncomment to enable.


### PR DESCRIPTION
Resolves #450 

`lineNos` - enables line numbers in code blocks
`lineNosInTable = false` - ensures css flex grid is used not HTML tables