### PR TITLE
Correct option for dump to use --extra-dump instead of --extra

### DIFF
--- a/content/troubleshooting/mysql-ssl-disabled.md
+++ b/content/troubleshooting/mysql-ssl-disabled.md
@@ -112,6 +112,7 @@ services:
                   extra: "--skip-ssl"
               dump:
                 options:
+                  extra: "--skip-ssl"
                   extra-dump: "--skip-ssl"
               query:
                 options:

--- a/content/troubleshooting/mysql-ssl-disabled.md
+++ b/content/troubleshooting/mysql-ssl-disabled.md
@@ -112,7 +112,7 @@ services:
                   extra: "--skip-ssl"
               dump:
                 options:
-                  extra: "--skip-ssl"
+                  extra-dump: "--skip-ssl"
               query:
                 options:
                   extra: "--skip-ssl"


### PR DESCRIPTION
I unfortunately ran into the problem documented on this page recently. The site was locked to MariaDB 10.6 because that is the latest version that Pantheon supports, so upgrading MariaDB was not a good option. Instead I used the `--skip-ssl` suggestion from this page.

In using it, I found that it worked except running `drush sql-dump` still did not work. This is because `sql-dump` has _both_ an `--extra` **and** `--extra-dump` argument. Both should be set when doing a dump. See the documentation at https://www.drush.org/13.x/commands/sql_dump/