### PR TITLE
Update info about getting help in use-the-cli.md

### DIFF
--- a/content/tugboat-cli/use-the-cli.md
+++ b/content/tugboat-cli/use-the-cli.md
@@ -1,13 +1,14 @@
 ---
-title: "Use the Cli"
+title: "Use the CLI"
 date: 2019-09-19T10:41:55-04:00
 weight: 3
 ---
 
 ## CLI commands
 
-Run `tugboat` to see a list of commands you can execute. You can view the help of any command by passing the `-h`
-or `--help` option, or use `tugboat help <command>`. Most of the commands support returning JSON by passing the `-j` or `--json` option.
+Run `tugboat` to see a list of commands you can execute. You can view the help of any command by passing the `-h` or
+`--help` option, or use `tugboat help <command>`. Most of the commands support returning JSON by passing the `-j` or
+`--json` option.
 
 A few common commands include:
 

--- a/content/tugboat-cli/use-the-cli.md
+++ b/content/tugboat-cli/use-the-cli.md
@@ -6,8 +6,8 @@ weight: 3
 
 ## CLI commands
 
-Run `tugboat help` to see a list of commands you can execute. You can view the help of any command by passing the `-h`
-or `--help` option. Most of the commands support returning JSON by passing the `-j` or `--json` option.
+Run `tugboat` to see a list of commands you can execute. You can view the help of any command by passing the `-h`
+or `--help` option, or use `tugboat help <command>`. Most of the commands support returning JSON by passing the `-j` or `--json` option.
 
 A few common commands include:
 


### PR DESCRIPTION
Resolves #462

Updates the first paragraph of [Use the Cli](https://docs.tugboatqa.com/tugboat-cli/use-the-cli/index.html) and corrects information about how to list `tugboat` commands and how to get help on specific commands.

Also, updates the title to "Use the CLI" (from "Use the Cli") because that was bothering me. 😅